### PR TITLE
Application shouldn't subclass dict

### DIFF
--- a/aiosip/application.py
+++ b/aiosip/application.py
@@ -13,7 +13,7 @@ from .protocol import UDP
 from .log import application_logger
 
 
-class Router(object):
+class Router:
     def __init__(self):
         self.routes = {}
 
@@ -21,8 +21,7 @@ class Router(object):
         self.routes[method] = handler
 
 
-class Application(dict):
-
+class Application:
     def __init__(self, *, logger=application_logger, loop=None):
         if loop is None:
             loop = asyncio.get_event_loop()


### PR DESCRIPTION
Guess at some point `Application` actually behaved like a dictionary, but it no longer does. Probably not desirable either way as this subclass leads to some unintentional behaviour:

~~~python
>>> import aiosip
>>> bool(aiosip.Application())
False
~~~

This makes `Application` instances harder to cache.