### PR TITLE
Added Proxy Authentication

### DIFF
--- a/aiosip/dialog.py
+++ b/aiosip/dialog.py
@@ -97,6 +97,22 @@ class Dialog:
                                       headers=original_msg.headers,
                                       payload=original_msg.payload,
                                       future=original_msg.future)
+                                      
+                # for call authorization
+                elif msg.status_code == 407:
+                    original_msg = self._msgs[msg.method].pop(msg.cseq)
+                    del(original_msg.headers['CSeq'])
+                    original_msg.headers['Proxy-Authorization'] = str(Auth.from_authenticate_header(
+                        authenticate=msg.headers['Proxy-Authenticate'],
+                        method=msg.method,
+                        uri=str(self.to_details),
+                        username=self.to_details['uri']['user'],
+                        password=self.password))
+                    self.send_message(msg.method,
+                                      headers=original_msg.headers,
+                                      payload=original_msg.payload,
+                                      future=original_msg.future)
+                                      
                 elif msg.status_code == 100:
                     pass
                 elif msg.status_code == 180:

--- a/aiosip/dialog.py
+++ b/aiosip/dialog.py
@@ -98,7 +98,7 @@ class Dialog:
                                       payload=original_msg.payload,
                                       future=original_msg.future)
                                       
-                # for call authorization
+                # for proxy authentication
                 elif msg.status_code == 407:
                     original_msg = self._msgs[msg.method].pop(msg.cseq)
                     del(original_msg.headers['CSeq'])


### PR DESCRIPTION
It is a very small change, but it is needed if a proxy authenticates a call. Since a lot of the information is repeated between www-authenticate and proxy-authenticate, there is likely a better way to add this.