### PR TITLE
Put the BYE message in the call's future

### DIFF
--- a/aiosip/call.py
+++ b/aiosip/call.py
@@ -34,8 +34,9 @@ class Call:
         self.dialog.send_message(method='ACK', headers=hdrs)
 
     def handle_bye(self, dialog, request):
-        print('Call disconnected by remote...')
-        self.gotbye.set_result(True)
+        if not self.gotbye.done():
+            print('Call disconnected by remote...')
+            self.gotbye.set_result(request)
 
     @asyncio.coroutine
     def close(self):
@@ -49,7 +50,7 @@ class Call:
                                                          headers=hdrs)
             assert new_ok.status_code == 200
             self._ack(new_ok)
-            self.gotbye.set_result(True)
+            self.gotbye.set_result(None)
 
     @property
     def active(self):


### PR DESCRIPTION
Been a while since I've had the freetime to work on aiosip.

Small change - put the BYE message inside the call's future. This allows me to inspect why a call was hungup on me:

~~~python
def report_call(future):
    result = future.result()
    if not done_originating and result:
        reason = result.headers['X-Asterisk-Hangupcause']
        print('Call hung up early: {}'.format(reason))

# ...

future = asyncio.Future()
future.add_done_callback(report_call)
call = await Call.invite(dialog, ..., future=future)
~~~