### PR TITLE
Always set a username for challenge response messages

### DIFF
--- a/aiosip/dialog.py
+++ b/aiosip/dialog.py
@@ -84,16 +84,19 @@ class Dialog:
                         hdrs['CSeq'] = msg.headers['CSeq'].replace('INVITE', 'ACK')
                         hdrs['Via'] = msg.headers['Via']
                         self.send_message(method='ACK', headers=hdrs)
+                    else:
+                        username = msg.from_details['uri']['user']
 
                     original_msg = self._msgs[msg.method].pop(msg.cseq)
                     del(original_msg.headers['CSeq'])
                     original_msg.headers['Authorization'] = str(Auth.from_authenticate_header(
                         authenticate=msg.headers['WWW-Authenticate'],
                         method=msg.method,
-                        uri=self.to_details.from_repr(),
+                        uri=msg.to_details['uri'].short_uri(),
                         username=username,
                         password=self.password))
-                    self.send_message(msg.method,
+                    self.send_message(original_msg.method,
+                                      to_details=original_msg.to_details,
                                       headers=original_msg.headers,
                                       payload=original_msg.payload,
                                       future=original_msg.future)


### PR DESCRIPTION
Sorry for my quietness, I've been increadibly slammed with other QA tasks and haven't had a chance to look at any of this stuff for months. Finally got some freed up time to focus on this library again.

Tweaked `recieve_message` to handle other challenge response messages. Tested it with SUBSCRIBE, which now works.