### PR TITLE
Initial transaction tracking support.

### DIFF
--- a/aiosip/application.py
+++ b/aiosip/application.py
@@ -141,7 +141,6 @@ class Application(MutableMapping):
         else:
             self.logger.debug('A new dialog starts...')
             route = self.dialplan.resolve(msg)
-            print(route)
             if route:
                 dialog = self.handle_incoming(protocol, msg, addr, route)
                 self.loop.call_soon(asyncio.ensure_future, dialog)

--- a/aiosip/application.py
+++ b/aiosip/application.py
@@ -7,7 +7,6 @@ __all__ = ['Application']
 
 import asyncio
 from collections import MutableMapping
-import weakref
 
 from .dialog import Dialog
 from .dialplan import Dialplan
@@ -26,7 +25,7 @@ class Application(MutableMapping):
         self.logger = logger
         self._finish_callbacks = []
         self.loop = loop
-        self._dialogs = weakref.WeakValueDictionary()
+        self._dialogs = {}
         self._state = {}
         self._protocols = {}
         self._transports = {}

--- a/aiosip/dialog.py
+++ b/aiosip/dialog.py
@@ -40,7 +40,7 @@ class Dialog:
         self.remote_addr = remote_addr
         self.password = password
         self.loop = loop
-        self.cseqs = defaultdict(int)
+        self.cseq = 0
         self._msgs = defaultdict(dict)
         self.callbacks = defaultdict(list)
         self.invite_current_attempt = None
@@ -160,19 +160,19 @@ class Dialog:
             from_details = self.from_details
         from_details.add_tag()
 
-        self.cseqs[method] += 1
+        self.cseq += 1
         msg = Request(method=method,
                       from_details=from_details,
                       to_details=to_details if to_details else self.to_details,
                       contact_details=contact_details if contact_details else self.contact_details,
-                      cseq=self.cseqs[method],
+                      cseq=self.cseq,
                       headers=headers,
                       content_type=content_type,
                       payload=payload)
         if future:
             msg.future = future
 
-        self._msgs[method][self.cseqs[method]] = msg
+        self._msgs[method][self.cseq] = msg
         self.protocol.send_message(msg)
         return msg.future if method != 'ACK' else None
 

--- a/examples/subscribe_server.py
+++ b/examples/subscribe_server.py
@@ -5,20 +5,30 @@ import aiosip
 
 
 @asyncio.coroutine
+def handle_subscribe(dialog, message):
+    for idx in range(1, 11):
+        dialog.send_message('NOTIFY',
+                            to_details=message.to_details,
+                            from_details=message.from_details,
+                            headers={'Via': message.headers['Via'],
+                                    'Call-ID': message.headers['Call-ID']},
+                            payload=str(idx))
+        yield from asyncio.sleep(1)
+
+
+@asyncio.coroutine
 def start_subscription(dialog, message):
-    print('Subscription started!')
-
-    headers = {
-        'Via': message.headers['Via'],
-        'CSeq': message.headers['CSeq'],
-        'Call-ID': message.headers['Call-ID']
-    }
-
+    assert message.method == 'REGISTER'
     dialog.send_reply(status_code=200,
                       status_message='OK',
                       to_details=message.to_details,
                       from_details=message.from_details,
-                      headers=headers)
+                      headers={'Via': message.headers['Via'],
+                               'CSeq': message.headers['CSeq'],
+                               'Call-ID': message.headers['Call-ID']})
+
+    print('Subscription started!')
+    dialog.register_callback('SUBSCRIBE', handle_subscribe)
 
 
 @asyncio.coroutine


### PR DESCRIPTION
Initial work to start encapsulating individual transactions. While currently it just moved the current transaction tracking logic out of the Dialog class, it opens the door to handling different kinds of transactions without messy branching logic, tracking state (setting up a callback to know when 180 arrived, for example), and properly supporting cancelling (send an appropriate CANCEL message).

Also fills in the server/client subscription example so that it actually sends arbitrary messages back and forth.

Next step is filling in some more transaction support to get a nicer API for the server side - support something in line with aiohttp's websocket support to handle incoming dialogs, map exceptions to error codes, and wrap responses for nice server code.