### PR TITLE
Add pytest support and a basic server/client test

### DIFF
--- a/aiosip/pytest_plugin.py
+++ b/aiosip/pytest_plugin.py
@@ -1,0 +1,133 @@
+import asyncio
+import contextlib
+import gc
+import sys
+
+import pytest
+
+
+try:
+    import uvloop
+except ImportError:  # pragma: no cover
+    uvloop = None
+
+
+LOOP_FACTORIES = []
+LOOP_FACTORY_IDS = []
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        '--fast', action='store_true', default=False,
+        help='run tests faster by disabling extra checks')
+    parser.addoption(
+        '--loop', action='store', default='pyloop',
+        help='run tests with specific loop: pyloop, uvloop, or all')
+    parser.addoption(
+        '--enable-loop-debug', action='store_true', default=False,
+        help='enable event loop debug mode')
+
+
+
+@contextlib.contextmanager
+def loop_context(loop_factory=asyncio.new_event_loop, fast=False):
+    """A contextmanager that creates an event_loop, for test purposes.
+    Handles the creation and cleanup of a test loop.
+    """
+    loop = setup_test_loop(loop_factory)
+    yield loop
+    teardown_test_loop(loop, fast=fast)
+
+
+def setup_test_loop(loop_factory=asyncio.new_event_loop):
+    """Create and return an asyncio.BaseEventLoop
+    instance.
+    The caller should also call teardown_test_loop,
+    once they are done with the loop.
+    """
+    loop = loop_factory()
+    asyncio.set_event_loop(None)
+    if sys.platform != "win32":
+        policy = asyncio.get_event_loop_policy()
+        watcher = asyncio.SafeChildWatcher()
+        watcher.attach_loop(loop)
+        policy.set_child_watcher(watcher)
+    return loop
+
+
+def teardown_test_loop(loop, fast=False):
+    """Teardown and cleanup an event_loop created
+    by setup_test_loop.
+    """
+    closed = loop.is_closed()
+    if not closed:
+        loop.call_soon(loop.stop)
+        loop.run_forever()
+        loop.close()
+
+    if not fast:
+        gc.collect()
+
+    asyncio.set_event_loop(None)
+
+
+def pytest_configure(config):
+    loops = config.getoption('--loop')
+
+    factories = {'pyloop': asyncio.new_event_loop}
+
+    if uvloop is not None:  # pragma: no cover
+        factories['uvloop'] = uvloop.new_event_loop
+
+    LOOP_FACTORIES.clear()
+    LOOP_FACTORY_IDS.clear()
+
+    if loops == 'all':
+        loops = 'pyloop,uvloop?,tokio?'
+
+    for name in loops.split(','):
+        required = not name.endswith('?')
+        name = name.strip(' ?')
+        if name in factories:
+            LOOP_FACTORIES.append(factories[name])
+            LOOP_FACTORY_IDS.append(name)
+        elif required:
+            raise ValueError(
+                "Unknown loop '%s', available loops: %s" % (
+                    name, list(factories.keys())))
+    asyncio.set_event_loop(None)
+
+
+def pytest_pycollect_makeitem(collector, name, obj):
+    """
+    Fix pytest collecting for coroutines.
+    """
+    if collector.funcnamefilter(name) and asyncio.iscoroutinefunction(obj):
+        return list(collector._genfunctions(name, obj))
+
+
+def pytest_pyfunc_call(pyfuncitem):
+    """
+    Run coroutines in an event loop instead of a normal function call.
+    """
+    if asyncio.iscoroutinefunction(pyfuncitem.function):
+        testargs = {arg: pyfuncitem.funcargs[arg]
+                    for arg in pyfuncitem._fixtureinfo.argnames}
+
+        _loop = pyfuncitem.funcargs.get('loop', None)
+        task = _loop.create_task(pyfuncitem.obj(**testargs))
+        _loop.run_until_complete(task)
+
+        return True
+
+
+@pytest.fixture(params=LOOP_FACTORIES, ids=LOOP_FACTORY_IDS)
+def loop(request):
+    """Return an instance of the event loop."""
+    fast = request.config.getoption('--fast')
+    debug = request.config.getoption('--enable-loop-debug')
+
+    with loop_context(request.param, fast=fast) as _loop:
+        if debug:
+            _loop.set_debug(True)  # pragma: no cover
+        yield _loop

--- a/aiosip/transaction.py
+++ b/aiosip/transaction.py
@@ -58,7 +58,7 @@ class UnreliableTransaction:
                 hdrs['From'] = msg.headers['From']
                 hdrs['To'] = msg.headers['To']
                 hdrs['Call-ID'] = msg.headers['Call-ID']
-                hdrs['CSeq'] = msg.headers['CSeq'].replace(self.orignial_msg.method, 'ACK')
+                hdrs['CSeq'] = msg.headers['CSeq'].replace(self.original_msg.method, 'ACK')
                 hdrs['Via'] = msg.headers['Via']
                 self.dialog.send(method='ACK', headers=hdrs)
             else:
@@ -123,9 +123,9 @@ class UnreliableTransaction:
         hdrs['From'] = self.original_msg.headers['From']
         hdrs['To'] = self.original_msg.headers['To']
         hdrs['Call-ID'] = self.original_msg.headers['Call-ID']
-        hdrs['CSeq'] = self.original_msg.headers['CSeq'].replace(self.orignial_msg.method, 'CANCEL')
+        hdrs['CSeq'] = self.original_msg.headers['CSeq'].replace(self.original_msg.method, 'CANCEL')
         hdrs['Via'] = self.original_msg.headers['Via']
-        self.send_message(method='CANCEL', headers=hdrs)
+        self.dialog.send(method='CANCEL', headers=hdrs)
 
     def _done_callback(self, result):
         if result.cancelled():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,59 @@
+import asyncio
+
+import aiosip
+import pytest
+
+
+pytest_plugins = ['aiosip.pytest_plugin']
+
+
+class TestServer:
+    def __init__(self, app, *, loop=None, host='127.0.0.1'):
+        self.loop = loop
+        self.host = host
+        self.app = app
+        self._loop = loop
+
+    @asyncio.coroutine
+    def start_server(self, *, loop=None):
+        self.handler = self.app.run(
+            protocol=aiosip.UDP,
+            local_addr=(self.sip_config['server_host'], self.sip_config['server_port'])
+        )
+        return self.handler
+
+    @asyncio.coroutine
+    def close(self):
+        pass
+
+    @property
+    def sip_config(self):
+        return {
+            'client_host': self.host,
+            'client_port': 7000,
+            'server_host': self.host,
+            'server_port': 6000,
+            'user': 'pytest',
+            'realm': 'example.com'
+        }
+
+
+@pytest.yield_fixture
+def test_server(loop):
+    servers = []
+
+    @asyncio.coroutine
+    def go(handler, **kwargs):
+        server = TestServer(handler)
+        yield from server.start_server(loop=loop, **kwargs)
+        servers.append(server)
+        return server
+
+    yield go
+
+    @asyncio.coroutine
+    def finalize():
+        while servers:
+            yield from servers.pop().close()
+
+    loop.run_until_complete(finalize())

--- a/tests/test_sip_server.py
+++ b/tests/test_sip_server.py
@@ -1,0 +1,43 @@
+import asyncio
+
+import aiosip
+
+
+@asyncio.coroutine
+def test_subscribe(test_server, loop):
+    callback_complete = loop.create_future()
+
+    @asyncio.coroutine
+    def handler(dialog, request):
+        response = aiosip.Response.from_request(
+            request=request,
+            status_code=200,
+            status_message='OK'
+        )
+        dialog.reply(response)
+        callback_complete.set_result(request)
+
+    app = aiosip.Application(loop=loop)
+    app.dialplan.add_user('pytest', {'SUBSCRIBE': handler})
+    server = yield from test_server(app)
+
+    connection = yield from app.connect(
+        local_addr=(server.sip_config['client_host'], server.sip_config['client_port']),
+        remote_addr=(server.sip_config['server_host'], server.sip_config['server_port'])
+    )
+
+    subscribe_dialog = connection.create_dialog(
+        from_uri='sip:{}@{}:{}'.format(server.sip_config['user'], server.sip_config['client_host'], server.sip_config['client_port']),
+        to_uri='sip:666@{}:{}'.format(server.sip_config['server_host'], server.sip_config['server_port']),
+    )
+
+    future = subscribe_dialog.send(
+        method='SUBSCRIBE',
+        headers={'Expires': '1800',
+                 'Event': 'dialog',
+                 'Accept': 'application/dialog-info+xml'}
+    )
+
+    yield from asyncio.wait_for(future, timeout=1)
+    request = yield from asyncio.wait_for(callback_complete, timeout=1)
+    assert request.method == 'SUBSCRIBE'


### PR DESCRIPTION
So the tests don't work yet, and I think I've found a few bugs already with this test (I have some typos in my earlier PR... 😰). But I think they're in good enough shape that they can be shared for review and merged in their current state. I'll finish them up tomorrow and integrate Travis as a I think I should be able to do that with my current permissions.

I borrowed ideas from aiohttp to enable both unit testing and a pytest plugin for others to test their own code with. Then port part of the subscribe server/client example a test to make sure it continues to work.

I also want to make sure uvloop has first class support as much as possible. My rough benchmarks when I first used uvloop + aiosip showed very promising performance.