### PR TITLE
Add travis integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,33 @@
-# Config file for automatic testing at travis-ci.org
+sudo: required
+services:
+  - docker
 
 language: python
 
 python:
-  - "3.4"
-  - "3.3"
-  - "2.7"
-  - "2.6"
-  - "pypy"
+  # - 3.5.2
+  - 3.5
+  - 3.6
 
-# command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
-install: pip install -r requirements.txt
+matrix:
+  allow_failures:
+    - python: '3.6-dev'
+    - python: 'nightly'
 
-# command to run tests, e.g. python setup.py test
-script: python setup.py test
+cache:
+  directories:
+  - $HOME/.cache/pip
+
+before_cache:
+  - rm -f $HOME/.cache/pip/log/debug.log
+
+install:
+  - pip install --upgrade pip wheel
+  - pip install --upgrade setuptools
+  - pip install pytest pytest-cov codecov uvloop -e .
+
+script:
+  - py.test --cov=aiosip --cov-report=term --cov-report=html --cov-append --loop pyloop,uvloop tests
+
+after_success:
+  - codecov

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+coverage:
+  range: "50..100"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,10 @@
 [wheel]
 universal = 1
+
+[coverage:run]
+branch = True
+source = aiosip, tests
+omit = site-packages
+
+[coverage:html]
+directory = coverage

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ requirements = [
 ]
 
 test_requirements = [
-    # TODO: put package test requirements here
+    'pytest'
 ]
 
 setup(

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,11 @@
 [tox]
-envlist = py26, py27, py33, py34
+envlist = py34,py35,py36
 
 [testenv]
-setenv =
-    PYTHONPATH = {toxinidir}:{toxinidir}/aiosip
-commands = python setup.py test
-deps =
-    -r{toxinidir}/requirements.txt
+deps = pytest
+commands = pytest {posargs:tests}
+
+[testenv:check]
+deps = wheel flake8
+commands = flake8 aiosip examples tests
+basepython = python3


### PR DESCRIPTION
Adds travis and codecov integration. Works and tested on the sangoma/aiosip repository, but I don't have permissions to add it here. Should be a matter of just turning everything on.

Once this is in, I'll add the badges to the README.