### PR TITLE
Parameterize tests over UDP and TCP

### DIFF
--- a/aiosip/connections.py
+++ b/aiosip/connections.py
@@ -19,7 +19,6 @@ class Connection:
         self.closed = False
 
     def send_message(self, msg):
-
         if self.closed:
             raise ConnectionError
 
@@ -36,7 +35,6 @@ class Connection:
         self.dialogs = {}
 
     def create_dialog(self, from_uri, to_uri, contact_uri=None, password=None, call_id=None, cseq=0, router=Router()):
-
         if self.closed:
             raise ConnectionError
 

--- a/aiosip/dialog.py
+++ b/aiosip/dialog.py
@@ -65,6 +65,8 @@ class Dialog:
                 t = asyncio.ensure_future(self._call_route(msg))
                 self._tasks.append(t)
                 await t
+            except asyncio.CancelledError:
+                pass
             except Exception as e:
                 LOG.exception(e)
                 response = Response.from_request(
@@ -167,6 +169,8 @@ class Dialog:
                     transaction.future.set_exception(ConnectionAbortedError)
         for task in self._tasks:
             task.cancel()
+
+        # TODO: this needs to be refactored
         self.connection.protocol.transport.close()
 
     def _connection_lost(self):

--- a/aiosip/dialog.py
+++ b/aiosip/dialog.py
@@ -167,6 +167,7 @@ class Dialog:
                     transaction.future.set_exception(ConnectionAbortedError)
         for task in self._tasks:
             task.cancel()
+        self.connection.protocol.transport.close()
 
     def _connection_lost(self):
         for transactions in self._transactions.values():
@@ -203,3 +204,9 @@ class Dialog:
                                     headers=headers,
                                     payload=sdp)
         return send_msg_future
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()

--- a/aiosip/pytest_plugin.py
+++ b/aiosip/pytest_plugin.py
@@ -34,10 +34,10 @@ def pytest_addoption(parser):
         help='enable event loop debug mode')
 
 
-
 @contextlib.contextmanager
 def loop_context(loop_factory=asyncio.new_event_loop, fast=False):
     """A contextmanager that creates an event_loop, for test purposes.
+
     Handles the creation and cleanup of a test loop.
     """
     loop = setup_test_loop(loop_factory)
@@ -46,10 +46,10 @@ def loop_context(loop_factory=asyncio.new_event_loop, fast=False):
 
 
 def setup_test_loop(loop_factory=asyncio.new_event_loop):
-    """Create and return an asyncio.BaseEventLoop
-    instance.
-    The caller should also call teardown_test_loop,
-    once they are done with the loop.
+    """Create and return an asyncio.BaseEventLoop instance.
+
+    The caller should also call teardown_test_loop, once they are done
+    with the loop.
     """
     loop = loop_factory()
     asyncio.set_event_loop(None)
@@ -62,9 +62,7 @@ def setup_test_loop(loop_factory=asyncio.new_event_loop):
 
 
 def teardown_test_loop(loop, fast=False):
-    """Teardown and cleanup an event_loop created
-    by setup_test_loop.
-    """
+    """Teardown and cleanup an event_loop created by setup_test_loop."""
     closed = loop.is_closed()
     if not closed:
         loop.call_soon(loop.stop)
@@ -108,17 +106,13 @@ def pytest_configure(config):
 
 
 def pytest_pycollect_makeitem(collector, name, obj):
-    """
-    Fix pytest collecting for coroutines.
-    """
+    """Fix pytest collecting for coroutines."""
     if collector.funcnamefilter(name) and asyncio.iscoroutinefunction(obj):
         return list(collector._genfunctions(name, obj))
 
 
 def pytest_pyfunc_call(pyfuncitem):
-    """
-    Run coroutines in an event loop instead of a normal function call.
-    """
+    """Run coroutines in an event loop instead of a normal function call."""
     if asyncio.iscoroutinefunction(pyfuncitem.function):
         testargs = {arg: pyfuncitem.funcargs[arg]
                     for arg in pyfuncitem._fixtureinfo.argnames}

--- a/tests/test_contact_parsing.py
+++ b/tests/test_contact_parsing.py
@@ -1,0 +1,35 @@
+import aiosip
+
+
+def test_simple_header():
+    header = aiosip.Contact.from_header('<sip:pytest@127.0.0.1:7000>')
+    assert not header['name']
+    assert dict(header['params']) == {}
+    assert dict(header['uri']) == {'scheme': 'sip',
+                                   'user': 'pytest',
+                                   'password': None,
+                                   'host': '127.0.0.1',
+                                   'port': 7000,
+                                   'params': None,
+                                   'headers': None}
+
+
+def test_header_with_name():
+    header = aiosip.Contact.from_header('"Pytest" <sip:pytest@127.0.0.1:7000>')
+    assert header['name'] == "Pytest"
+    assert dict(header['params']) == {}
+    assert dict(header['uri']) == {'scheme': 'sip',
+                                   'user': 'pytest',
+                                   'password': None,
+                                   'host': '127.0.0.1',
+                                   'port': 7000,
+                                   'params': None,
+                                   'headers': None}
+
+
+def test_add_tag():
+    header = aiosip.Contact.from_header('<sip:pytest@127.0.0.1:7000>')
+    assert dict(header['params']) == {}
+
+    header.add_tag()
+    assert 'tag' in header['params']

--- a/tests/test_sip_server.py
+++ b/tests/test_sip_server.py
@@ -4,7 +4,7 @@ import aiosip
 
 
 @asyncio.coroutine
-def test_subscribe(test_server, loop):
+def test_subscribe(test_server, protocol, loop):
     callback_complete = loop.create_future()
 
     @asyncio.coroutine
@@ -22,6 +22,7 @@ def test_subscribe(test_server, loop):
     server = yield from test_server(app)
 
     connection = yield from app.connect(
+        protocol=protocol,
         local_addr=(server.sip_config['client_host'], server.sip_config['client_port']),
         remote_addr=(server.sip_config['server_host'], server.sip_config['server_port'])
     )

--- a/tests/test_sip_server.py
+++ b/tests/test_sip_server.py
@@ -9,6 +9,13 @@ def test_subscribe(test_server, protocol, loop):
 
     @asyncio.coroutine
     def handler(dialog, request):
+        # TODO: putting the context manager here guarantees that we
+        # close this connection, but its technically broken. Closing
+        # the dialog here in turn cancels this coroutine, so it
+        # doesn't actually complete properly.
+        #
+        # Without this, though, the tests don't run, so its a
+        # necessary evil for now.
         with dialog:
             response = aiosip.Response.from_request(
                 request=request,


### PR DESCRIPTION
Makes sure we test both UDP and TCP over both the python event loop and uvloop. Had to add a few hacks to make sure we properly cleanup connections between tests in order to make sure the tests pass.