### PR TITLE
Queues in transaction

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ services:
 language: python
 
 python:
-  # - 3.5.2
-  - 3.5
+#  - 3.5.2
+#  - 3.5
   - 3.6
 
 matrix:

--- a/aiosip/application.py
+++ b/aiosip/application.py
@@ -90,7 +90,6 @@ class Application(MutableMapping):
         key = msg.headers['Call-ID']
         dialog = peer._dialogs.get(key)
         if not dialog:
-            LOG.debug('New dialog for %s, ID: "%s"', peer, key)
             dialog = peer.create_dialog(
                 from_details=Contact.from_header(msg.headers['To']),
                 to_details=Contact.from_header(msg.headers['From']),

--- a/aiosip/application.py
+++ b/aiosip/application.py
@@ -84,7 +84,7 @@ class Application(MutableMapping):
         server = await connector.create_server(local_addr, sock)
         return server
 
-    async def dispatch(self, protocol, msg, addr):
+    async def _dispatch(self, protocol, msg, addr):
         connector = self._connectors[type(protocol)]
         peer = await connector.get_peer(protocol, addr)
         key = msg.headers['Call-ID']

--- a/aiosip/dialog.py
+++ b/aiosip/dialog.py
@@ -134,12 +134,14 @@ class Dialog:
             async for response in self.start_transaction(msg):
                 yield response
         elif isinstance(Response, msg) or msg.method == 'ACK':
-            yield self.peer.send_message(msg)
+            self.peer.send_message(msg)
+            return
         elif as_request:
             async for response in self.start_transaction(msg):
                 yield response
         else:
-            yield self.peer.send_message(msg)
+            self.peer.send_message(msg)
+            return
 
     def reply(self, request, status_code, status_message=None, payload=None, headers=None, contact_details=None):
         self.from_details.add_tag()
@@ -254,7 +256,7 @@ class Dialog:
             to_details=self.to_details,
             contact_details=self.contact_details,
         )
-        self.send(ack)
+        await self.send(ack)
 
     def __enter__(self):
         return self

--- a/aiosip/dialog.py
+++ b/aiosip/dialog.py
@@ -56,7 +56,7 @@ class Dialog:
             transaction = self.transactions[msg.method][msg.cseq]
             transaction._incoming(msg)
         except KeyError:
-            raise RuntimeError('This Response SIP message doesn\'t have a Request: "%s"' % msg)
+            LOG.debug('Response without Request. The Transaction may already be closed. \n%s', msg)
 
     async def _receive_request(self, msg):
 

--- a/aiosip/dialplan.py
+++ b/aiosip/dialplan.py
@@ -63,8 +63,8 @@ class ProxyRouter(Router):
     def __init__(self):
         super().__init__(default=self.proxy)
 
-    async def proxy(self, dialog, msg):
+    async def proxy(self, dialog, msg, timeout=5):
         peer = await utils.get_proxy_peer(dialog, msg)
-        async for proxy_response in peer.proxy_request(dialog, msg):
+        async for proxy_response in peer.proxy_request(dialog, msg, timeout=timeout):
             if proxy_response:
                 dialog.peer.proxy_response(proxy_response)

--- a/aiosip/dialplan.py
+++ b/aiosip/dialplan.py
@@ -65,6 +65,6 @@ class ProxyRouter(Router):
 
     async def proxy(self, dialog, msg):
         peer = await utils.get_proxy_peer(dialog, msg)
-        proxy_response = await peer.proxy_request(dialog, msg)
-        if proxy_response:
-            dialog.peer.proxy_response(proxy_response)
+        async for proxy_response in peer.proxy_request(dialog, msg):
+            if proxy_response:
+                dialog.peer.proxy_response(proxy_response)

--- a/aiosip/exceptions.py
+++ b/aiosip/exceptions.py
@@ -3,6 +3,10 @@ class AiosipException(Exception):
     pass
 
 
+class AuthentificationFailed(PermissionError):
+    pass
+
+
 class RegisterFailed(AiosipException):
     pass
 

--- a/aiosip/message.py
+++ b/aiosip/message.py
@@ -241,7 +241,6 @@ class Request(Message):
                  contact_details=None,
                  headers=None,
                  payload=None,
-                 future=None,
                  first_line=None
                  ):
 
@@ -253,7 +252,7 @@ class Request(Message):
             contact_details=contact_details
         )
 
-        self._method = method
+        self._method = method.upper()
         self._cseq = cseq
 
         if not first_line:

--- a/aiosip/peers.py
+++ b/aiosip/peers.py
@@ -105,9 +105,11 @@ class Peer:
         )
 
         if msg.method != 'ACK':
-            return await proxy_dialog.start_proxy_transaction(msg, dialog.peer)
+            async for response in proxy_dialog.start_proxy_transaction(msg, dialog.peer):
+                yield response
         else:
-            return self.send_message(msg)
+            self.send_message(msg)
+            return
 
     def proxy_response(self, msg):
         msg.headers['Via'].pop(0)

--- a/aiosip/peers.py
+++ b/aiosip/peers.py
@@ -79,7 +79,7 @@ class Peer:
         self._dialogs[call_id] = dialog
         return dialog
 
-    async def proxy_request(self, dialog, msg):
+    async def proxy_request(self, dialog, msg, timeout=5):
         proxy_dialog = self._dialogs.get(dialog.call_id)
         if not proxy_dialog:
             proxy_dialog = self.create_dialog(
@@ -108,7 +108,7 @@ class Peer:
         )
 
         if msg.method != 'ACK':
-            async for response in proxy_dialog.start_proxy_transaction(msg):
+            async for response in proxy_dialog.start_proxy_transaction(msg, timeout=timeout):
                 yield response
         else:
             self.send_message(msg)

--- a/aiosip/peers.py
+++ b/aiosip/peers.py
@@ -40,9 +40,9 @@ class Peer:
 
     def create_dialog(self, from_details, to_details, contact_details=None, password=None, call_id=None, cseq=0,
                       router=Router()):
-        LOG.debug('Creating dialog %s for peer %s', call_id, self)
         if not call_id:
             call_id = str(uuid.uuid4())
+        LOG.debug('Creating dialog %s for peer %s', call_id, self)
 
         if not contact_details:
             host, port = self.local_addr

--- a/aiosip/protocol.py
+++ b/aiosip/protocol.py
@@ -35,7 +35,7 @@ class UDP(asyncio.DatagramProtocol):
         msg = message.Message.from_raw_headers(headers)
         msg._raw_payload = data
         LOG.log(5, 'Received via UDP: "%s"', msg)
-        asyncio.ensure_future(self.app.dispatch(self, msg, addr))
+        asyncio.ensure_future(self.app._dispatch(self, msg, addr))
 
     # def error_received(self, exc):
     #     print('Error received:', exc)
@@ -80,7 +80,7 @@ class TCP(asyncio.Protocol):
             msg._raw_payload, self._data = self._data[:content_length], self._data[content_length:]
             # assert len(msg._raw_payload) == int(msg.headers['Content-Length'])
             LOG.log(5, 'Received via TCP: "%s"', msg)
-            asyncio.ensure_future(self.app.dispatch(self, msg, None))
+            asyncio.ensure_future(self.app._dispatch(self, msg, None))
 
     # def error_received(self, exc):
     #     print('Error received:', exc)

--- a/aiosip/transaction.py
+++ b/aiosip/transaction.py
@@ -110,14 +110,16 @@ class UnreliableTransaction(BaseTransaction):
 
         if msg.status_code == 401 and 'WWW-Authenticate' in msg.headers:
             self._handle_authenticate(msg)
+            return
         elif msg.status_code == 407:  # Proxy authentication
             self._handle_proxy_authenticate(msg)
+            return
         elif self.original_msg.method.upper() == 'INVITE' and msg.status_code == 200:
             self.dialog.ack(msg)
-            self._incomings.put_nowait(msg)
-        else:
+
+        self._incomings.put_nowait(msg)
+        if msg.status_code >= 200:
             self._terminated = True
-            self._incomings.put_nowait(msg)
             self._incomings.put_nowait(None)
 
     async def _timer(self, timeout=0.5):

--- a/aiosip/transaction.py
+++ b/aiosip/transaction.py
@@ -21,7 +21,7 @@ class BaseTransaction:
     async def start(self):
         raise NotImplementedError
 
-    def incoming(self, msg):
+    def _incoming(self, msg):
         raise NotImplementedError
 
     async def _start(self):
@@ -66,7 +66,7 @@ class BaseTransaction:
             password=self.dialog.password)
         )
 
-        self.dialog._transactions[self.original_msg.method][self.original_msg.cseq] = self
+        self.dialog.transactions[self.original_msg.method][self.original_msg.cseq] = self
         self.dialog.peer.send_message(self.original_msg)
 
     def _handle_proxy_authenticate(self, msg):
@@ -101,7 +101,7 @@ class UnreliableTransaction(BaseTransaction):
         async for response in self._start():
             yield response
 
-    def incoming(self, msg):
+    def _incoming(self, msg):
         if self._terminated:
             return
 
@@ -159,7 +159,7 @@ class ProxyTransaction(BaseTransaction):
         async for response in self._start():
             yield response
 
-    def incoming(self, msg):
+    def _incoming(self, msg):
         self._incomings.put_nowait(msg)
 
     def retransmit(self):

--- a/aiosip/transaction.py
+++ b/aiosip/transaction.py
@@ -66,7 +66,8 @@ class BaseTransaction:
             password=self.dialog.password)
         )
 
-        self.dialog.send(self.original_msg)
+        self.dialog._transactions[self.original_msg.method][self.original_msg.cseq] = self
+        self.dialog.peer.send_message(self.original_msg)
 
     def _handle_proxy_authenticate(self, msg):
         self._handle_proxy_authenticate(msg)

--- a/examples/subscribe_client.py
+++ b/examples/subscribe_client.py
@@ -18,11 +18,11 @@ sip_config = {
 
 async def show_notify(dialog, request):
     print('NOTIFY:', request.payload)
-    dialog.reply(request, status_code=200)
+    await dialog.reply(request, status_code=200)
 
 
 async def option(dialog, request):
-    dialog.reply(request, status_code=200)
+    await dialog.reply(request, status_code=200)
 
 
 async def start(app, protocol):
@@ -37,8 +37,7 @@ async def start(app, protocol):
         password=sip_config['pwd'],
     )
 
-    async for response in register_dialog.request(method='REGISTER', headers={'Expires': 1800}):
-        assert response.status_code == 200
+    await register_dialog.register()
 
     subscribe_dialog = peer.create_dialog(
         from_details=aiosip.Contact.from_header(
@@ -49,15 +48,9 @@ async def start(app, protocol):
     )
 
     subscribe_dialog.router['notify'] = show_notify
-    headers = {'Expires': '1800', 'Event': 'dialog', 'Accept': 'application/dialog-info+xml'}
-    async for response in subscribe_dialog.request(method='SUBSCRIBE', headers=headers):
-        assert response.status_code == 200
-
+    await subscribe_dialog.subscribe()
     await asyncio.sleep(20)
-
-    headers = {'Expires': '0', 'Event': 'dialog', 'Accept': 'application/dialog-info+xml'}
-    async for response in subscribe_dialog.request(method='SUBSCRIBE', headers=headers):
-        assert response.status_code == 200
+    await subscribe_dialog.subscribe(expires=0)
 
 
 def main():

--- a/examples/subscribe_client.py
+++ b/examples/subscribe_client.py
@@ -16,53 +16,48 @@ sip_config = {
 }
 
 
-@asyncio.coroutine
-def show_notify(dialog, request):
+async def show_notify(dialog, request):
     print('NOTIFY:', request.payload)
     dialog.reply(request, status_code=200)
 
 
-@asyncio.coroutine
-def option(dialog, request):
+async def option(dialog, request):
     dialog.reply(request, status_code=200)
 
 
-@asyncio.coroutine
-def start(app, protocol):
+async def start(app, protocol):
 
-    connection = yield from app.connect((sip_config['srv_host'], sip_config['srv_port']),
-                                        protocol)
+    peer = await app.connect((sip_config['srv_host'], sip_config['srv_port']), protocol)
 
-    register_dialog = connection.create_dialog(
+    register_dialog = peer.create_dialog(
         from_details=aiosip.Contact.from_header(
             'sip:{}@{}:{}'.format(sip_config['user'], sip_config['local_ip'], sip_config['local_port'])),
         to_details=aiosip.Contact.from_header(
             'sip:{}@{}:{}'.format(sip_config['user'], sip_config['srv_host'], sip_config['srv_port'])),
         password=sip_config['pwd'],
     )
-    yield from register_dialog.request(
-        method='REGISTER',
-        headers={'Expires': 1800}
-    )
-    register_dialog.close()
 
-    subscribe_dialog = connection.create_dialog(
+    async for response in register_dialog.request(method='REGISTER', headers={'Expires': 1800}):
+        assert response.status_code == 200
+
+    subscribe_dialog = peer.create_dialog(
         from_details=aiosip.Contact.from_header(
             'sip:{}@{}:{}'.format(sip_config['user'], sip_config['local_ip'], sip_config['local_port'])),
         to_details=aiosip.Contact.from_header(
             'sip:666@{}:{}'.format(sip_config['srv_host'], sip_config['srv_port'])),
         password=sip_config['pwd']
     )
-    subscribe_dialog.register_callback('NOTIFY', show_notify)
-    yield from subscribe_dialog.request(
-        method='SUBSCRIBE',
-        headers={'Expires': '1800',
-                 'Event': 'dialog',
-                 'Accept': 'application/dialog-info+xml'}
-    )
 
-    yield from asyncio.sleep(20)
-    subscribe_dialog.close()
+    subscribe_dialog.router['notify'] = show_notify
+    headers = {'Expires': '1800', 'Event': 'dialog', 'Accept': 'application/dialog-info+xml'}
+    async for response in subscribe_dialog.request(method='SUBSCRIBE', headers=headers):
+        assert response.status_code == 200
+
+    await asyncio.sleep(20)
+
+    headers = {'Expires': '0', 'Event': 'dialog', 'Accept': 'application/dialog-info+xml'}
+    async for response in subscribe_dialog.request(method='SUBSCRIBE', headers=headers):
+        assert response.status_code == 200
 
 
 def main():

--- a/examples/subscribe_server.py
+++ b/examples/subscribe_server.py
@@ -17,18 +17,17 @@ sip_config = {
 
 async def notify(dialog):
     for idx in range(1, 4):
-        async for response in dialog.request('NOTIFY', payload=str(idx)):
-            assert response.status_code == 200
+        await dialog.notify(payload=str(idx))
         await asyncio.sleep(1)
 
 
 async def on_register(dialog, message):
-    dialog.reply(message, status_code=200)
+    await dialog.reply(message, status_code=200)
     print('Registration successful')
 
 
 async def on_subscribe(dialog, message):
-    dialog.reply(message, status_code=200)
+    await dialog.reply(message, status_code=200)
 
     if int(message.headers['Expires']):
         print('Subscription started!')

--- a/examples/subscribe_server.py
+++ b/examples/subscribe_server.py
@@ -15,25 +15,26 @@ sip_config = {
 }
 
 
-@asyncio.coroutine
-def notify(dialog):
+async def notify(dialog):
     for idx in range(1, 4):
-        yield from dialog.request('NOTIFY',
-                                  payload=str(idx))
-        yield from asyncio.sleep(1)
+        async for response in dialog.request('NOTIFY', payload=str(idx)):
+            assert response.status_code == 200
+        await asyncio.sleep(1)
 
 
-@asyncio.coroutine
-def on_register(dialog, message):
+async def on_register(dialog, message):
     dialog.reply(message, status_code=200)
     print('Registration successful')
 
 
-@asyncio.coroutine
-def on_subscribe(dialog, message):
+async def on_subscribe(dialog, message):
     dialog.reply(message, status_code=200)
-    print('Subscription started!')
-    yield from notify(dialog)
+
+    if int(message.headers['Expires']):
+        print('Subscription started!')
+        await notify(dialog)
+    else:
+        print('Subscription ended!')
 
 
 def main_tcp(app):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -96,3 +96,21 @@ def test_proxy(protocol, loop):
             yield from servers.pop().close()
 
     loop.run_until_complete(finalize())
+
+
+@pytest.fixture
+def from_details(request):
+    return 'sip:{user}@{host}:{port}'.format(
+        user='pytest',
+        host='127.0.0.1',
+        port=7000
+    )
+
+
+@pytest.fixture
+def to_details(request):
+    return 'sip:{user}@{host}:{port}'.format(
+        user='666',
+        host='127.0.0.1',
+        port=6000
+    )

--- a/tests/test_sip_proxy.py
+++ b/tests/test_sip_proxy.py
@@ -62,11 +62,12 @@ async def test_proxy_notify(test_server, test_proxy, protocol, loop, from_detail
         await dialog.notify(payload='1')
 
     async def notify(dialog, request):
+        await dialog.reply(request, 200)
         callback_complete.set_result(request)
 
     async def proxy_notify(dialog, request):
-        callback_complete_proxy.set_result(request)
         await dialog.router.proxy(dialog, request)
+        callback_complete_proxy.set_result(request)
 
     app = aiosip.Application(loop=loop)
 

--- a/tests/test_sip_proxy.py
+++ b/tests/test_sip_proxy.py
@@ -11,8 +11,8 @@ async def test_proxy_subscribe(test_server, test_proxy, protocol, loop, from_det
         callback_complete.set_result(request)
 
     async def proxy_subscribe(dialog, request):
+        await dialog.router.proxy(dialog, request, timeout=0.1)
         callback_complete_proxy.set_result(request)
-        await dialog.router.proxy(dialog, request)
 
     app = aiosip.Application(loop=loop)
 
@@ -66,7 +66,7 @@ async def test_proxy_notify(test_server, test_proxy, protocol, loop, from_detail
         callback_complete.set_result(request)
 
     async def proxy_notify(dialog, request):
-        await dialog.router.proxy(dialog, request)
+        await dialog.router.proxy(dialog, request, timeout=0.1)
         callback_complete_proxy.set_result(request)
 
     app = aiosip.Application(loop=loop)

--- a/tests/test_sip_scenario.py
+++ b/tests/test_sip_scenario.py
@@ -1,0 +1,97 @@
+import aiosip
+import asyncio
+
+
+async def test_notify(test_server, protocol, loop, from_details, to_details):
+    notify_list = [0, 1, 2, 3, 4]
+    received_notify_futures = [loop.create_future() for _ in notify_list]
+
+    async def subscribe(dialog, request):
+        assert len(dialog.peer.subscriber) == 1
+        dialog.reply(request, status_code=200)
+        await asyncio.sleep(0.1)
+
+        for i in notify_list:
+            async for rep in dialog.request(method='NOTIFY', payload=str(i)):
+                assert rep.status_code == 200
+
+    async def notify(dialog, request):
+        received_notify_futures[int(request.payload)].set_result(request)
+        dialog.reply(request, status_code=200)
+
+    app = aiosip.Application(loop=loop)
+    server_app = aiosip.Application(loop=loop)
+    server_app.dialplan.add_user('pytest', {'SUBSCRIBE': subscribe})
+    server = await test_server(server_app)
+
+    peer = await app.connect(
+        protocol=protocol,
+        remote_addr=(server.sip_config['server_host'], server.sip_config['server_port'])
+    )
+
+    client_router = aiosip.Router()
+    client_router['notify'] = notify
+
+    subscribe_dialog = peer.create_dialog(
+        from_details=aiosip.Contact.from_header(from_details),
+        to_details=aiosip.Contact.from_header(to_details),
+        router=client_router
+    )
+
+    responses = list()
+    headers = {'Expires': '1800', 'Event': 'dialog', 'Accept': 'application/dialog-info+xml'}
+    async for response in subscribe_dialog.request(method='SUBSCRIBE', headers=headers):
+        responses.append(response)
+
+    done, pending = await asyncio.wait(received_notify_futures, return_when=asyncio.ALL_COMPLETED, timeout=1)
+    received_notify = [f.result() for f in done]
+    assert len(pending) == 0
+
+    assert len(responses) == 1
+    assert responses[0].status_code == 200
+    assert responses[0].status_message == 'OK'
+    assert all((r.method == 'NOTIFY' for r in received_notify))
+
+    server_app.close()
+
+
+async def test_authentification(test_server, protocol, loop, from_details, to_details):
+    password = 'abcdefg'
+    received_request = list()
+
+    async def subscribe(dialog, request):
+        if dialog.validate_auth(request, password):
+            received_request.append(request)
+            dialog.reply(request, 200)
+        else:
+            received_request.append(request)
+            dialog.unauthorized(request)
+
+    app = aiosip.Application(loop=loop)
+    server_app = aiosip.Application(loop=loop)
+    server_app.dialplan.add_user('pytest', {'SUBSCRIBE': subscribe})
+    server = await test_server(server_app)
+
+    peer = await app.connect(
+        protocol=protocol,
+        remote_addr=(server.sip_config['server_host'], server.sip_config['server_port'])
+    )
+
+    subscribe_dialog = peer.create_dialog(
+        from_details=aiosip.Contact.from_header(from_details),
+        to_details=aiosip.Contact.from_header(to_details),
+        password=password
+    )
+
+    responses = list()
+    headers = {'Expires': '1800', 'Event': 'dialog', 'Accept': 'application/dialog-info+xml'}
+    async for response in subscribe_dialog.request(method='SUBSCRIBE', headers=headers):
+        responses.append(response)
+
+    assert len(responses) == 1
+    assert len(received_request) == 2
+    assert 'Authorization' in received_request[1].headers
+    assert responses[0].status_code == 200
+    assert responses[0].status_message == 'OK'
+
+    server_app.close()

--- a/tests/test_sip_server.py
+++ b/tests/test_sip_server.py
@@ -1,5 +1,3 @@
-import asyncio
-
 import aiosip
 
 
@@ -137,68 +135,4 @@ async def test_exception_in_handler(test_server, protocol, loop):
     assert len(responses) == 1
     assert responses[0].status_code == 500
     assert responses[0].status_message == 'Server Internal Error'
-    server_app.close()
-
-
-async def test_notify(test_server, protocol, loop):
-    callback_complete = loop.create_future()
-
-    async def subscribe(dialog, request):
-        assert len(dialog.peer.subscriber) == 1
-        dialog.reply(request, status_code=200)
-        await asyncio.sleep(0.2)
-        async for _ in dialog.request(method='NOTIFY', payload='1'):  # noqa: F841
-            pass
-
-    async def notify(dialog, request):
-        callback_complete.set_result(request)
-
-    app = aiosip.Application(loop=loop)
-
-    server_app = aiosip.Application(loop=loop)
-    server_app.dialplan.add_user('pytest', {'SUBSCRIBE': subscribe})
-    server = await test_server(server_app)
-
-    peer = await app.connect(
-        protocol=protocol,
-        remote_addr=(server.sip_config['server_host'], server.sip_config['server_port'])
-    )
-
-    from_details = 'sip:{user}@{host}:{port}'.format(
-        user=server.sip_config['user'],
-        host=server.sip_config['client_host'],
-        port=server.sip_config['client_port']
-    )
-    to_details = 'sip:666@{host}:{port}'.format(
-        host=server.sip_config['server_host'],
-        port=server.sip_config['server_port']
-    )
-
-    client_router = aiosip.Router()
-    client_router['notify'] = notify
-
-    subscribe_dialog = peer.create_dialog(
-        from_details=aiosip.Contact.from_header(from_details),
-        to_details=aiosip.Contact.from_header(to_details),
-        router=client_router
-    )
-
-    responses = list()
-    headers = {
-        'Expires': '1800',
-        'Event': 'dialog',
-        'Accept': 'application/dialog-info+xml'
-    }
-    async for response in subscribe_dialog.request(method='SUBSCRIBE', headers=headers):
-        responses.append(response)
-
-    received_notify = await callback_complete
-
-    assert len(responses) == 1
-    assert responses[0].status_code == 200
-    assert responses[0].status_message == 'OK'
-
-    assert received_notify.method == 'NOTIFY'
-    assert received_notify.payload == '1'
-
     server_app.close()

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35,py36,flake8
+envlist = py36,flake8
 
 [testenv]
 deps =


### PR DESCRIPTION
Lots of stuff moving around.

I believe it's best to use queues in transaction instead of a single `future` so we can pass the 100-200 status code response. It also allow better proxying of re-transmission. I'm not sure I did it the best way possible but it's a WIP.

At the moment it uses `async iterator` that are only available on 3.6. 
- Should we drop 3.5 ?
- It might be possible to do the same with `__aiter__` and `__anext__` ?
- Any ideas ?