### PR TITLE
Keep track of local addr for peer

### DIFF
--- a/aiosip/application.py
+++ b/aiosip/application.py
@@ -60,8 +60,7 @@ class Application(MutableMapping):
     @property
     def peers(self):
         for connector in self._connectors.values():
-            for peers in connector._peers.values():
-                yield from peers
+            yield from connector._peers.values()
 
     @property
     def dialogs(self):

--- a/aiosip/application.py
+++ b/aiosip/application.py
@@ -60,7 +60,8 @@ class Application(MutableMapping):
     @property
     def peers(self):
         for connector in self._connectors.values():
-            yield from connector._peers.values()
+            for peers in connector._peers.values():
+                yield from peers
 
     @property
     def dialogs(self):

--- a/aiosip/utils.py
+++ b/aiosip/utils.py
@@ -1,6 +1,10 @@
 import random
 import string
 import ipaddress
+import logging
+
+
+LOG = logging.getLogger(__name__)
 
 EOL = '\r\n'
 BYTES_EOL = b'\r\n'
@@ -106,13 +110,12 @@ async def get_proxy_peer(dialog, msg):
 
     if (host, port) == dialog.peer.peer_addr or (host, port) == dialog.contact_details:
         for peer in dialog.app.peers:
-            if msg.method == 'NOTIFY':
-                if msg.to_details['uri']['user'] in peer.subscriber:
-                    return peer
-            elif msg.to_details['uri']['user'] in peer.registered:
+            if msg.method == 'NOTIFY' and peer.subscriber[msg.to_details['uri']['user']]:
+                return peer
+            if msg.to_details['uri']['user'] in peer.registered:
                 return peer
         else:
-            raise ValueError('No proxy peer found for: {}'.format(msg))
+            raise RuntimeError('No proxy peer found for: {}'.format(msg))
     else:
         host = await get_host_ip(msg.to_details['uri']['host'], dialog.app.dns)
         port = msg.to_details['uri']['port'] or dialog.from_details['uri']['port']


### PR DESCRIPTION
This allow to run multiple endpoints and find the right peer
when they don't switch outgoing port

We can't use (peer_addr, local_addr) as key in the self._peers
dict as the local_addr is only know when the connection is
establisehd. It could lead to race condition when creating
connections to the same peer.