### PR TITLE
Introduce helper to track messages/requests that expire

### DIFF
--- a/aiosip/contrib.py
+++ b/aiosip/contrib.py
@@ -1,0 +1,22 @@
+import asyncio
+
+
+def session(function):
+    tasks = {}
+
+    async def closure(dialog, message):
+        call_id = message.headers["Call-ID"]
+        expires = int(message.headers["Expires"])
+
+        await dialog.reply(message, status_code=200)
+
+        if expires > 0:
+            future = asyncio.ensure_future(function(dialog, message))
+            tasks[call_id] = future
+            await future
+        else:
+            future = tasks.get(call_id)
+            if future and not future.done():
+                future.cancel()
+
+    return closure

--- a/examples/subscribe_server.py
+++ b/examples/subscribe_server.py
@@ -3,6 +3,7 @@ import logging
 import sys
 
 import aiosip
+from aiosip.contrib import session
 
 sip_config = {
     'srv_host': 'xxxxxx',
@@ -27,13 +28,13 @@ async def on_register(dialog, message):
 
 
 async def on_subscribe(dialog, message):
-    await dialog.reply(message, status_code=200)
-
-    if int(message.headers['Expires']):
+    try:
         print('Subscription started!')
         await notify(dialog)
-    else:
-        print('Subscription ended!')
+    except asyncio.CancelledError:
+        pass
+
+    print('Subscription ended!')
 
 
 def main_tcp(app):
@@ -73,7 +74,7 @@ def main():
     loop = asyncio.get_event_loop()
     app = aiosip.Application(loop=loop)
     app.dialplan.add_user('subscriber', {'REGISTER': on_register,
-                                         'SUBSCRIBE': on_subscribe})
+                                         'SUBSCRIBE': session(on_subscribe)})
 
     if len(sys.argv) > 1 and sys.argv[1] == 'tcp':
         main_tcp(app)


### PR DESCRIPTION
Putting this up because I would like to start working on some sort of API to make server implementation easier. I would like to eventually get to something like how aiohttp server side has a request object and then move this mechanism to something closer to how aiohttp handles websockets (this API obviously prevents you from rejecting traffic). I envision something like:

```python
async def my_subscription(request):
    subscription = asyncio.Subscription()
    await subscription.prepare(request)

    for i in range(4):
        subscription.send(i)
    return subscription
```

But this PR gets me part of the way there.