### PR TITLE
Actually close protocol / transport

### DIFF
--- a/aiosip/peers.py
+++ b/aiosip/peers.py
@@ -40,7 +40,7 @@ class Peer:
 
             if self._protocol is not None:
                 LOG.debug('Closing connection for %s', self)
-                self._connector._release(self.peer_addr, self._protocol, should_close=True)
+                self._connector._release(self.peer_addr, self._protocol)
                 self._protocol = None
 
     def send_message(self, msg):
@@ -278,12 +278,12 @@ class BaseConnector:
         for peer in self._peers.values():
             peer.close()
 
-    def _release(self, peer_addr, protocol, should_close=False):
-        _protocol = self._protocols.pop(peer_addr, None)
+    def _release(self, peer_addr, protocol):
+        local_addr = protocol.transport.get_extra_info('sockname')
+        _protocol = self._protocols.pop((peer_addr, local_addr), None)
         if _protocol:
             assert _protocol == protocol
-            if should_close:
-                protocol.transport.close()
+            protocol.transport.close()
 
     async def _create_server(self, local_addr, sock):
         raise NotImplementedError()

--- a/examples/subscribe_client.py
+++ b/examples/subscribe_client.py
@@ -54,6 +54,7 @@ async def start(app, protocol):
     await subscribe_dialog.subscribe()
     await asyncio.sleep(20)
     await subscribe_dialog.subscribe(expires=0)
+    peer.close()
 
 
 def main():


### PR DESCRIPTION
The code which is supposed to close the transport was not being
called as the lookup on self._protocols was using the wrong key.

Also eliminate the "should_close" argument which is always True.