### PR TITLE
Make app.close() async, unify 'server' interface

### DIFF
--- a/aiosip/application.py
+++ b/aiosip/application.py
@@ -132,9 +132,9 @@ class Application(MutableMapping):
     def register_on_finish(self, func, *args, **kwargs):
         self._finish_callbacks.insert(0, (func, args, kwargs))
 
-    def close(self):
+    async def close(self):
         for connector in self._connectors.values():
-            connector.close()
+            await connector.close()
 
     # def __repr__(self):
     #     return "<Application>"

--- a/examples/subscribe_client.py
+++ b/examples/subscribe_client.py
@@ -57,7 +57,8 @@ async def start(app, protocol):
     await subscribe_dialog.subscribe()
     await asyncio.sleep(20)
     await subscribe_dialog.subscribe(expires=0)
-    peer.close()
+
+    await app.close()
 
 
 def main():

--- a/examples/subscribe_server.py
+++ b/examples/subscribe_server.py
@@ -37,15 +37,15 @@ async def on_subscribe(dialog, message):
     print('Subscription ended!')
 
 
-def main_tcp(app):
-    server = app.loop.run_until_complete(
+def start(app, protocol):
+    app.loop.run_until_complete(
         app.run(
-            protocol=aiosip.TCP,
+            protocol=protocol,
             local_addr=(sip_config['local_ip'], sip_config['local_port'])
         )
     )
 
-    print('Serving on {} TCP'.format(server.sockets[0].getsockname()))
+    print('Serving on {} {}'.format((sip_config['local_ip'], sip_config['local_port']), protocol))
 
     try:
         app.loop.run_forever()
@@ -53,41 +53,7 @@ def main_tcp(app):
         pass
 
     print('Closing')
-    server.close()
-    app.loop.run_until_complete(server.wait_closed())
-
-
-def main_udp(app):
-    app.loop.run_until_complete(app.run(local_addr=(sip_config['local_ip'], sip_config['local_port'])))
-
-    print('Serving on {} UDP'.format((sip_config['local_ip'], sip_config['local_port'])))
-
-    try:
-        app.loop.run_forever()
-    except KeyboardInterrupt:
-        pass
-
-    print('Closing')
-
-
-def main_ws(app):
-    server = app.loop.run_until_complete(
-        app.run(
-            protocol=aiosip.WS,
-            local_addr=(sip_config['local_ip'], sip_config['local_port'])
-        )
-    )
-
-    print('Serving WS')
-
-    try:
-        app.loop.run_forever()
-    except KeyboardInterrupt:
-        pass
-
-    print('Closing')
-    server.close()
-    app.loop.run_until_complete(server.wait_closed())
+    app.loop.run_until_complete(app.close())
 
 
 def main():
@@ -97,13 +63,13 @@ def main():
                                          'SUBSCRIBE': session(on_subscribe)})
 
     if len(sys.argv) > 1 and sys.argv[1] == 'tcp':
-        main_tcp(app)
+        start(app, aiosip.TCP)
     elif len(sys.argv) > 1 and sys.argv[1] == 'ws':
-        main_ws(app)
+        start(app, aiosip.WS)
     else:
-        main_udp(app)
+        start(app, aiosip.UDP)
 
-    # loop.close()
+    loop.close()
 
 
 if __name__ == '__main__':

--- a/tests/test_sip_proxy.py
+++ b/tests/test_sip_proxy.py
@@ -47,8 +47,9 @@ async def test_proxy_subscribe(test_server, test_proxy, protocol, loop, from_det
     assert received_request_server.payload == received_request_proxy.payload
     assert received_request_server.headers == received_request_proxy.headers
 
-    server_app.close()
-    proxy_app.close()
+    await server_app.close()
+    await proxy_app.close()
+    await app.close()
 
 
 async def test_proxy_notify(test_server, test_proxy, protocol, loop, from_details, to_details):
@@ -109,5 +110,6 @@ async def test_proxy_notify(test_server, test_proxy, protocol, loop, from_detail
     assert received_notify_server.payload == received_notify_proxy.payload
     assert received_notify_server.headers == received_notify_proxy.headers
 
-    server_app.close()
-    proxy_app.close()
+    await server_app.close()
+    await proxy_app.close()
+    await app.close()

--- a/tests/test_sip_scenario.py
+++ b/tests/test_sip_scenario.py
@@ -51,7 +51,8 @@ async def test_notify(test_server, protocol, loop, from_details, to_details):
     assert response.status_message == 'OK'
     assert all((r.method == 'NOTIFY' for r in received_notify))
 
-    server_app.close()
+    await server_app.close()
+    await app.close()
 
 
 async def test_authentification(test_server, protocol, loop, from_details, to_details):
@@ -89,7 +90,8 @@ async def test_authentification(test_server, protocol, loop, from_details, to_de
     assert response.status_code == 200
     assert response.status_message == 'OK'
 
-    server_app.close()
+    await server_app.close()
+    await app.close()
 
 
 async def test_invite(test_server, protocol, loop, from_details, to_details):

--- a/tests/test_sip_server.py
+++ b/tests/test_sip_server.py
@@ -31,7 +31,8 @@ async def test_subscribe(test_server, protocol, loop, from_details, to_details):
     assert response.status_message == 'OK'
     assert received_request.method == 'SUBSCRIBE'
 
-    server_app.close()
+    await server_app.close()
+    await app.close()
 
 
 async def test_response_404(test_server, protocol, loop, from_details, to_details):
@@ -51,7 +52,9 @@ async def test_response_404(test_server, protocol, loop, from_details, to_detail
     response = await subscribe_dialog.subscribe()
     assert response.status_code == 404
     assert response.status_message == 'Not Found'
-    server_app.close()
+
+    await server_app.close()
+    await app.close()
 
 
 async def test_response_501(test_server, protocol, loop, from_details, to_details):
@@ -72,7 +75,9 @@ async def test_response_501(test_server, protocol, loop, from_details, to_detail
     response = await subscribe_dialog.subscribe()
     assert response.status_code == 501
     assert response.status_message == 'Not Implemented'
-    server_app.close()
+
+    await server_app.close()
+    await app.close()
 
 
 async def test_exception_in_handler(test_server, protocol, loop, from_details, to_details):
@@ -100,4 +105,6 @@ async def test_exception_in_handler(test_server, protocol, loop, from_details, t
 
     assert response.status_code == 500
     assert response.status_message == 'Server Internal Error'
-    server_app.close()
+
+    await server_app.close()
+    await app.close()


### PR DESCRIPTION
The "_create_server" method returned something very different depending on whether the transport was UDP or TCP/WS. In the UDP case what was returned was in fact the protocol, which has neither "close" nor "await_closed()" methods.

These kind of differences should not be exposed outside the API boundary, as they mean special cases in our users' code.

Also, make app.close() the preferred way of shutting down the application.