### PR TITLE
[peers] lowercase transport in Contact address

### DIFF
--- a/aiosip/peers.py
+++ b/aiosip/peers.py
@@ -68,7 +68,7 @@ class Peer:
                     'uri': 'sip:{username}@{host_and_port};transport={protocol}'.format(
                         username=from_details['uri']['user'],
                         host_and_port=utils.format_host_and_port(host, port),
-                        protocol=type(self._protocol).__name__.upper()
+                        protocol=type(self._protocol).__name__.lower()
                     )
                 }
             )


### PR DESCRIPTION
The transport specified in the Contact address should be lowercase
according to RFC 3261.