### PR TITLE
Improve Contact header parsing

### DIFF
--- a/aiosip/contact.py
+++ b/aiosip/contact.py
@@ -9,10 +9,26 @@ from .uri import Uri
 from .utils import gen_str
 
 
-# Regex pattern from p2p-sip project
-CONTACT_PATTERNS = [re.compile('^(?P<name>[a-zA-Z0-9\-\._\+~ \t]*)<(?P<uri>[^>]+)>(?:;(?P<params>[^\?]*))?'),
-                    re.compile('^(?:"(?P<name>[^"]+)")[ \t]*<(?P<uri>[^>]+)>(?:;(?P<params>[^\?]*))?'),
-                    re.compile('^[ \t]*(?P<name>)(?P<uri>[^;]+)(?:;(?P<params>[^\?]*))?')]
+CONTACT_PATTERNS = [
+    # unquoted name
+    re.compile('^(?P<name>[a-zA-Z0-9\-\.!%\*_\+`\'~]*)'
+               '[ \t]*'
+               '<(?P<uri>[^>]+)>'
+               '[ \t]*'
+               '(?:;(?P<params>[^\?]*))?'),
+    # quoted name
+    re.compile('^(?:"(?P<name>[^"]+)")'
+               '[ \t]*'
+               '<(?P<uri>[^>]+)>'
+               '[ \t]*'
+               '(?:;(?P<params>[^\?]*))?'),
+    # no name
+    re.compile('(?P<name>)'
+               '[ \t]*'
+               '(?P<uri>[^ ;]+)'
+               '[ \t]*'
+               '(?:;(?P<params>[^\?]*))?'),
+]
 
 
 LOG = logging.getLogger(__name__)
@@ -44,13 +60,6 @@ class Contact(MutableMapping):
                 return cls(m.groupdict())
         else:
             raise ValueError('Not valid contact address')
-
-    def from_repr(self):
-        r = str(self._contact['uri'])
-        params = self._contact['params']
-        if params:
-            r += ';%s' % str(params)
-        return r
 
     def __str__(self):
         r = ''

--- a/tests/test_contact_parsing.py
+++ b/tests/test_contact_parsing.py
@@ -12,9 +12,25 @@ def test_simple_header():
                                    'port': 7000,
                                    'params': None,
                                    'headers': None}
+    assert str(header) == '<sip:pytest@127.0.0.1:7000>'
 
 
-def test_header_with_name():
+def test_header_with_name_and_params():
+    # RFC 3261 - 8.1.1.3
+    header = aiosip.Contact.from_header('Anonymous <sip:c8oqz84zk7z@privacy.org>;tag=hyh8')
+    assert header['name'] == "Anonymous"
+    assert dict(header['params']) == {'tag': 'hyh8'}
+    assert dict(header['uri']) == {'scheme': 'sip',
+                                   'user': 'c8oqz84zk7z',
+                                   'password': None,
+                                   'host': 'privacy.org',
+                                   'port': None,
+                                   'params': None,
+                                   'headers': None}
+    assert str(header) == '"Anonymous" <sip:c8oqz84zk7z@privacy.org>;tag=hyh8'
+
+
+def test_header_with_quoted_name():
     header = aiosip.Contact.from_header('"Pytest" <sip:pytest@127.0.0.1:7000>')
     assert header['name'] == "Pytest"
     assert dict(header['params']) == {}
@@ -25,6 +41,37 @@ def test_header_with_name():
                                    'port': 7000,
                                    'params': None,
                                    'headers': None}
+    assert str(header) == '"Pytest" <sip:pytest@127.0.0.1:7000>'
+
+
+def test_header_with_quoted_name_and_space_before_params():
+    # RFC 3261 - 8.1.1.3
+    header = aiosip.Contact.from_header('"Bob" <sips:bob@biloxi.com> ;tag=a48s')
+    assert header['name'] == 'Bob'
+    assert dict(header['params']) == {'tag': 'a48s'}
+    assert dict(header['uri']) == {'scheme': 'sips',
+                                   'user': 'bob',
+                                   'password': None,
+                                   'host': 'biloxi.com',
+                                   'port': None,
+                                   'params': None,
+                                   'headers': None}
+    assert str(header) == '"Bob" <sips:bob@biloxi.com>;tag=a48s'
+
+
+def test_header_without_brackets():
+    # RFC 3261 - 8.1.1.3
+    header = aiosip.Contact.from_header('sip:+12125551212@phone2net.com;tag=887s')
+    assert not header['name']
+    assert dict(header['params']) == {'tag': '887s'}
+    assert dict(header['uri']) == {'scheme': 'sip',
+                                   'user': '+12125551212',
+                                   'password': None,
+                                   'host': 'phone2net.com',
+                                   'port': None,
+                                   'params': None,
+                                   'headers': None}
+    assert str(header) == '<sip:+12125551212@phone2net.com>;tag=887s'
 
 
 def test_add_tag():


### PR DESCRIPTION
- accept all tokens in unquoted name
- don't put whitespace into name
- correctly parse params when there is a space before params

Also:
- add tests for transforming the Contact back to a header string
- remove dead 'from_repr' code