### PR TITLE
[RFC] Initial sketch for joining INVITE transaction to the dialog

### DIFF
--- a/aiosip/dialog2.py
+++ b/aiosip/dialog2.py
@@ -1,0 +1,199 @@
+import asyncio
+from collections import defaultdict
+import enum
+import logging
+
+from multidict import CIMultiDict
+
+from .dialog import Dialog
+from .message import Request, Response
+from .transaction import UnreliableTransaction
+
+
+class CallState(enum.Enum):
+    Calling = enum.auto()
+    Proceeding = enum.auto()
+    Completed = enum.auto()
+    Terminated = enum.auto()
+
+
+LOG = logging.getLogger(__name__)
+
+
+class DialogSetup:
+    def __init__(self,
+                 app,
+                 from_details,
+                 to_details,
+                 call_id,
+                 peer,
+                 contact_details,
+                 *,
+                 password=None,
+                 router=None,
+                 cseq=0):
+
+        self.app = app
+        self.from_details = from_details
+        self.to_details = to_details
+        self.contact_details = contact_details
+        self.call_id = call_id
+        self.peer = peer
+        self.password = password
+        self.cseq = cseq
+
+        self.msg = self._prepare_request('INVITE')
+        self.transactions = defaultdict(dict)
+
+        self._dialog = None
+        self._queue = asyncio.Queue()
+        self._state = CallState.Calling
+        self._waiter = asyncio.Future()
+
+    @property
+    def state(self):
+        return self._state
+
+    async def receive_message(self, msg):
+        async def set_result(msg):
+            self._ack(msg)
+            if not self._waiter.done():
+                self._waiter.set_result(msg)
+            await self._queue.put(msg)
+
+        if self._state == CallState.Calling:
+            if 100 <= msg.status_code < 200:
+                self._state = CallState.Proceeding
+
+            elif msg.status_code == 200:
+                self._state = CallState.Terminated
+                await set_result(msg)
+
+            elif 300 <= msg.status_code < 700:
+                self._state = CallState.Completed
+                await set_result(msg)
+
+            pass
+
+        elif self._state == CallState.Proceeding:
+            if 100 <= msg.status_code < 200:
+                await self._queue.put(msg)
+
+            elif msg.status_code == 200:
+                self._state = CallState.Terminated
+                await set_result(msg)
+
+            elif 300 <= msg.status_code < 700:
+                self._state = CallState.Completed
+                await set_result(msg)
+
+            pass
+
+        elif self._state == CallState.Completed:
+            # Any additional messages in this state MUST be acked but
+            # are NOT to be passed up
+            self._ack(msg)
+            # TODO: flip to Terminated after timeout
+            pass
+
+        elif self._state == CallState.Terminated:
+            if isinstance(msg, Response) or msg.method == 'ACK':
+                return self._receive_response(msg)
+            else:
+                return await self._receive_request(msg)
+
+    def _receive_response(self, msg):
+        try:
+            transaction = self.transactions[msg.method][msg.cseq]
+            transaction._incoming(msg)
+        except KeyError:
+            LOG.debug('Response without Request. The Transaction may already be closed. \n%s', msg)
+
+    async def wait_for_terminate(self):
+        while not self._waiter.done():
+            yield await self._queue.get()
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc_info):
+        await self.close()
+
+    def _get_dialog(self):
+        if not self._dialog:
+            self._dialog = Dialog(
+                app=self.app,
+                from_details=self.from_details,
+                to_details=self.to_details,
+                contact_details=self.contact_details,
+                call_id=self.call_id,
+                peer=self.peer,
+                password=self.password,
+                cseq=self.cseq,
+            )
+
+        return self._dialog
+
+    async def start(self):
+        self.peer.send_message(self.msg)
+
+    async def close(self):
+        msg = self._prepare_request('BYE')
+        transaction = UnreliableTransaction(self, original_msg=msg, loop=self.app.loop)
+        self.transactions[msg.method][msg.cseq] = transaction
+        return await transaction.start()
+
+    async def wait(self):
+        msg = await self._waiter
+        if msg.status_code != 200:
+            raise RuntimeError("INVITE failed with {}".format(msg.status_code))
+        return self._get_dialog
+
+    def __repr__(self):
+        return '<{} {} call_id={}, peer={}>'.format(self.__class__.__name__,
+                                                    self.state, self.call_id,
+                                                    self.peer)
+
+    def _ack(self, msg, headers=None, *args, **kwargs):
+        headers = CIMultiDict(headers or {})
+
+        headers['Via'] = msg.headers['Via']
+        ack = self._prepare_request('ACK', cseq=msg.cseq, to_details=msg.to_details, headers=headers, *args, **kwargs)
+        self.peer.send_message(ack)
+
+    def _prepare_request(self, method, contact_details=None, headers=None, payload=None, cseq=None, to_details=None):
+        self.from_details.add_tag()
+        if not cseq:
+            self.cseq += 1
+
+        if contact_details:
+            self.contact_details = contact_details
+
+        headers = CIMultiDict(headers or {})
+
+        if 'User-Agent' not in headers:
+            headers['User-Agent'] = self.app.defaults['user_agent']
+
+        headers['Call-ID'] = self.call_id
+
+        msg = Request(
+            method=method,
+            cseq=cseq or self.cseq,
+            from_details=self.from_details,
+            to_details=to_details or self.to_details,
+            contact_details=self.contact_details,
+            headers=headers,
+            payload=payload,
+        )
+        return msg
+
+    def end_transaction(self, transaction):
+        to_delete = list()
+        for method, values in self.transactions.items():
+            for cseq, t in values.items():
+                if transaction is t:
+                    transaction.close()
+                    to_delete.append((method, cseq))
+
+        for item in to_delete:
+            del self.transactions[item[0]][item[1]]

--- a/examples/invite_client.py
+++ b/examples/invite_client.py
@@ -1,0 +1,63 @@
+import asyncio
+import logging
+import random
+import sys
+
+import aiosip
+
+sip_config = {
+    'srv_host': '127.0.0.1',
+    'srv_port': 6000,
+    'realm': 'XXXXXX',
+    'user': 'aiosip',
+    'pwd': 'hunter2',
+    'local_ip': '127.0.0.1',
+    'local_port': random.randint(6001, 6100)
+}
+
+
+async def option(dialog, request):
+    await dialog.reply(request, status_code=200)
+
+
+async def start(app, protocol):
+    if protocol is aiosip.WS:
+        peer = await app.connect('ws://{}:{}'.format(sip_config['srv_host'], sip_config['srv_port']), protocol)
+    else:
+        peer = await app.connect((sip_config['srv_host'], sip_config['srv_port']), protocol)
+
+    dialog = await peer.invite(
+        from_details=aiosip.Contact.from_header('sip:{}@{}:{}'.format(sip_config['user'], sip_config['local_ip'], sip_config['local_port'])),
+        to_details=aiosip.Contact.from_header('sip:{}@{}:{}'.format(sip_config['user'], sip_config['srv_host'], sip_config['srv_port'])),
+        password=sip_config['pwd'],
+    )
+
+    async with dialog:
+        async for msg in dialog.wait_for_terminate():
+            print("CALL STATUS:", msg.status_code)
+
+        print("CALL ESTABLISHED")
+        await asyncio.sleep(5)
+        print("GOING AWAY...")
+
+    print("CALL TERMINATED")
+
+
+def main():
+    loop = asyncio.get_event_loop()
+    app = aiosip.Application(loop=loop)
+    app.dialplan.add_user('asterisk', option)
+
+    if len(sys.argv) > 1 and sys.argv[1] == 'tcp':
+        loop.run_until_complete(start(app, aiosip.TCP))
+    elif len(sys.argv) > 1 and sys.argv[1] == 'ws':
+        loop.run_until_complete(start(app, aiosip.WS))
+    else:
+        loop.run_until_complete(start(app, aiosip.UDP))
+
+    loop.close()
+
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.DEBUG)
+    main()

--- a/examples/invite_server.py
+++ b/examples/invite_server.py
@@ -1,0 +1,110 @@
+import asyncio
+import logging
+import sys
+
+import aiosip
+
+sip_config = {
+    'srv_host': 'xxxxxx',
+    'srv_port': '7000',
+    'realm': 'XXXXXX',
+    'user': 'YYYYYY',
+    'pwd': 'ZZZZZZ',
+    'local_ip': '127.0.0.1',
+    'local_port': 6000
+}
+
+
+async def notify(dialog):
+    for idx in range(1, 4):
+        await dialog.notify(payload=str(idx))
+        await asyncio.sleep(1)
+
+
+async def on_bye(dialog, message):
+    await dialog.reply(message, status_code=200)
+    print('Hangup successful')
+
+
+async def on_invite(dialog, message):
+    print('Call ringing!')
+    await dialog.reply(message, status_code=100)
+    await dialog.reply(message, status_code=180)
+
+    await asyncio.sleep(3)
+    await dialog.reply(message, status_code=200)
+    print('Call started!')
+
+
+def main_tcp(app):
+    server = app.loop.run_until_complete(
+        app.run(
+            protocol=aiosip.TCP,
+            local_addr=(sip_config['local_ip'], sip_config['local_port'])
+        )
+    )
+
+    print('Serving on {} TCP'.format(server.sockets[0].getsockname()))
+
+    try:
+        app.loop.run_forever()
+    except KeyboardInterrupt:
+        pass
+
+    print('Closing')
+    server.close()
+    app.loop.run_until_complete(server.wait_closed())
+
+
+def main_udp(app):
+    app.loop.run_until_complete(app.run(local_addr=(sip_config['local_ip'], sip_config['local_port'])))
+
+    print('Serving on {} UDP'.format((sip_config['local_ip'], sip_config['local_port'])))
+
+    try:
+        app.loop.run_forever()
+    except KeyboardInterrupt:
+        pass
+
+    print('Closing')
+
+
+def main_ws(app):
+    server = app.loop.run_until_complete(
+        app.run(
+            protocol=aiosip.WS,
+            local_addr=(sip_config['local_ip'], sip_config['local_port'])
+        )
+    )
+
+    print('Serving WS')
+
+    try:
+        app.loop.run_forever()
+    except KeyboardInterrupt:
+        pass
+
+    print('Closing')
+    server.close()
+    app.loop.run_until_complete(server.wait_closed())
+
+
+def main():
+    loop = asyncio.get_event_loop()
+    app = aiosip.Application(loop=loop)
+    app.dialplan.add_user('aiosip', {'INVITE': on_invite,
+                                     'BYE': on_bye})
+
+    if len(sys.argv) > 1 and sys.argv[1] == 'tcp':
+        main_tcp(app)
+    elif len(sys.argv) > 1 and sys.argv[1] == 'ws':
+        main_ws(app)
+    else:
+        main_udp(app)
+
+    # loop.close()
+
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.DEBUG)
+    main()


### PR DESCRIPTION
This is awful code, I've duplicated the Dialog class with `dialog2`, with the `invite` method, and other stuff.

However, the INVITE example works (at least UDP/TCP)...

So, I'm bringing this up now as we could discuss how to refactor this. I think maybe it makes more sense to implement `__aiter__` on dialogs to process incoming messages rather than having a router. There's potentially too much state in play to do anything differently. For example, I think its weird handling reinvites with a `INVITE` router callback when its so coupled to the dialog directly...

But if that's the case, does that simplify the current design? I suspect we might not need to maintain `QueueTransaction` with such a change, but I don't know how that would affect your proxying logic...