### PR TITLE
Make dialog iterable instead of relying on a default handler

### DIFF
--- a/aiosip/dialplan.py
+++ b/aiosip/dialplan.py
@@ -23,7 +23,9 @@ class Dialplan:
 
 class Router(MutableMapping):
     def __init__(self, default=None):
-        self._routes = {'*': default}
+        self._routes = {}
+        if default:
+            self._routes['*'] = default
 
     # MutableMapping API
     def __eq__(self, other):

--- a/tests/test_sip_server.py
+++ b/tests/test_sip_server.py
@@ -35,28 +35,6 @@ async def test_subscribe(test_server, protocol, loop, from_details, to_details):
     await app.close()
 
 
-async def test_response_404(test_server, protocol, loop, from_details, to_details):
-    app = aiosip.Application(loop=loop)
-    server_app = aiosip.Application(loop=loop)
-    server = await test_server(server_app)
-    peer = await app.connect(
-        protocol=protocol,
-        remote_addr=(server.sip_config['server_host'], server.sip_config['server_port'])
-    )
-
-    subscribe_dialog = peer.create_dialog(
-        from_details=aiosip.Contact.from_header(from_details),
-        to_details=aiosip.Contact.from_header(to_details),
-    )
-
-    response = await subscribe_dialog.subscribe()
-    assert response.status_code == 404
-    assert response.status_message == 'Not Found'
-
-    await server_app.close()
-    await app.close()
-
-
 async def test_response_501(test_server, protocol, loop, from_details, to_details):
     app = aiosip.Application(loop=loop)
     server_app = aiosip.Application(loop=loop)


### PR DESCRIPTION
This API lets me work with a dialog without having to explicitly register a callback for every message.

It also means that there's no more implicit 404 handling either, but I'm not convinced you want to do that inside a dialog. I think that makes sense for the dialplan, but once a dialog is established, we probably want every incoming message to be explicitly handled, and with awareness of the order they arrived in.

Related to #65, but I'm going to close that and do it in two parts. If we get this in, I think it might make sense to look at removing or simplifying QueueTransaction API, and then proper INVITE support.
