### PR TITLE
Move dialplan logic fully into Application, remove dialog router

### DIFF
--- a/aiosip/dialplan.py
+++ b/aiosip/dialplan.py
@@ -1,6 +1,5 @@
 import logging
 
-from . import utils
 from collections import MutableMapping
 
 
@@ -51,15 +50,3 @@ class Router(MutableMapping):
 
     def __iter__(self):
         return iter(self._routes)
-
-
-class ProxyRouter(Router):
-    def __init__(self):
-        super().__init__(default=self.proxy)
-
-    async def proxy(self, dialog, msg, timeout=5):
-        peer = await utils.get_proxy_peer(dialog, msg)
-        LOG.debug('Proxying "%s, %s, %s" from "%s" to "%s"', msg.cseq, msg.method, dialog.call_id, dialog.peer, peer)
-        async for proxy_response in peer.proxy_request(dialog, msg, timeout=timeout):
-            if proxy_response:
-                dialog.peer.proxy_response(proxy_response)

--- a/aiosip/transaction.py
+++ b/aiosip/transaction.py
@@ -234,6 +234,7 @@ class ProxyTransaction(QueueTransaction):
                     self._closing.cancel()
                 yield response
                 self._closing = self.dialog.app.loop.call_later(self._timeout, self.dialog.end_transaction, self)
+                self._running = False
 
     def _incoming(self, msg):
         self._result(msg)

--- a/tests/test_sip_server.py
+++ b/tests/test_sip_server.py
@@ -4,9 +4,9 @@ import aiosip
 async def test_subscribe(test_server, protocol, loop, from_details, to_details):
     callback_complete = loop.create_future()
 
-    async def handler(dialog, request):
-        await dialog.reply(request, status_code=200)
-        callback_complete.set_result(request)
+    async def handler(request, message):
+        await request.prepare(status_code=200)
+        callback_complete.set_result(message)
 
     app = aiosip.Application(loop=loop)
 
@@ -56,7 +56,6 @@ async def test_response_501(test_server, protocol, loop, from_details, to_detail
 
 
 async def test_exception_in_handler(test_server, protocol, loop, from_details, to_details):
-
     async def handler(dialog, request):
         raise RuntimeError('TestError')
 


### PR DESCRIPTION
Putting this up for feedback. I know you guys have been kinda busy, so take your time, still a few things left to do:

The PR removes the dialog router. I plan to move everything to using an iterator based API.

In order to do this, I created a new Request class to represent a new potential dialog. This now fed to the callbacks registered in the dialplan, and give them room to either reject or accept traffic. Should it be accepted, a Dialog is returned.

This returned dialog object should now behave exactly like the client side dialog, meaning future messages on that dialog should be read out by iterating (enabling re-REGISTER support, for example).

This breaks two features, authentication (can be retrofitted in, just haven't yet), and proxying.

Proxying will probably need a completely new implementation that's built around coroutines and iterators instead of routing hooks.