### PR TITLE
Drop python 3.5 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,6 @@ setup(
         'License :: OSI Approved :: Apache Software License',
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Topic :: Communications',
         'Topic :: Communications :: Internet Phone',


### PR DESCRIPTION
We use async generators, so no 3.5 support - unless someone wants to spend the time to re-add it.