### PR TITLE
Dialog rework with provisonal INVITE support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,6 +31,7 @@ Features tested on production
 * REGISTER
 * NOTIFY
 * SUBSCRIBE
+* INVITE
 * MESSAGE
 
 Missing features

--- a/aiosip/application.py
+++ b/aiosip/application.py
@@ -104,6 +104,7 @@ class Application(MutableMapping):
             def _create_dialog(self):
                 if not self.dialog:
                     self.dialog = peer._create_dialog(
+                        method=msg.method,
                         from_details=Contact.from_header(msg.headers['To']),
                         to_details=Contact.from_header(msg.headers['From']),
                         call_id=call_id
@@ -142,13 +143,14 @@ class Application(MutableMapping):
 
         async def reply(*args, **kwargs):
             dialog = peer._create_dialog(
+                method=msg.method,
                 from_details=Contact.from_header(msg.headers['To']),
                 to_details=Contact.from_header(msg.headers['From']),
                 call_id=key
             )
 
             await dialog.reply(*args, **kwargs)
-            dialog.close()
+            await dialog.close(fast=True)
 
         if not router:
             await reply(msg, status_code=501)

--- a/aiosip/dialog.py
+++ b/aiosip/dialog.py
@@ -1,4 +1,5 @@
 import asyncio
+import enum
 import logging
 
 from collections import defaultdict
@@ -6,16 +7,25 @@ from multidict import CIMultiDict
 
 from . import utils
 from .message import Request, Response
-from .transaction import UnreliableTransaction, ProxyTransaction, QueueTransaction
+from .transaction import UnreliableTransaction, ProxyTransaction
+
 from .auth import Auth
 
 
 LOG = logging.getLogger(__name__)
 
 
-class Dialog:
+class CallState(enum.Enum):
+    Calling = enum.auto()
+    Proceeding = enum.auto()
+    Completed = enum.auto()
+    Terminated = enum.auto()
+
+
+class DialogBase:
     def __init__(self,
                  app,
+                 method,
                  from_details,
                  to_details,
                  call_id,
@@ -34,154 +44,20 @@ class Dialog:
         self.password = password
         self.cseq = cseq
         self.transactions = defaultdict(dict)
-        self.callbacks = defaultdict(list)
-        self._nonce = None
-        self._closing = None
-        self._incoming = asyncio.Queue()
 
-    async def receive_message(self, msg):
-        if self._closing:
-            self._closing.cancel()
-
-        if self.cseq < msg.cseq:
-            self.cseq = msg.cseq
-
-        if isinstance(msg, Response) or msg.method == 'ACK':
-            return self._receive_response(msg)
-        else:
-            return await self._receive_request(msg)
+        # TODO: Needs to be last because we need the above attributes set
+        self.original_msg = self._prepare_request(method)
 
     def _receive_response(self, msg):
         try:
             transaction = self.transactions[msg.method][msg.cseq]
             transaction._incoming(msg)
         except KeyError:
-            LOG.debug('Response without Request. The Transaction may already be closed. \n%s', msg)
-
-    async def _queue_request(self, msg):
-        await self._incoming.put(msg)
-
-    async def _receive_request(self, msg):
-        self.peer._bookkeeping(msg, self.call_id)
-
-        if 'tag' in msg.from_details['params']:
-            self.to_details['params']['tag'] = msg.from_details['params']['tag']
-
-        await self._queue_request(msg)
-        self._maybe_close(msg)
-
-    async def unauthorized(self, msg):
-        self._nonce = utils.gen_str(10)
-        headers = CIMultiDict()
-        headers['WWW-Authenticate'] = str(Auth(nonce=self._nonce, algorithm='md5', realm='sip'))
-        await self.reply(msg, status_code=401, headers=headers)
-
-    def validate_auth(self, msg, password):
-        if msg.auth and msg.auth.validate(password, self._nonce):
-            self._nonce = None
-            return True
-        elif msg.method == 'CANCEL':
-            return True
-        else:
-            return False
-
-    async def start_unreliable_transaction(self, msg, method=None):
-        transaction = UnreliableTransaction(self, original_msg=msg, loop=self.app.loop)
-        self.transactions[method or msg.method][msg.cseq] = transaction
-        return await transaction.start()
-
-    async def start_queue_transaction(self, msg):
-        transaction = QueueTransaction(dialog=self, original_msg=msg, loop=self.app.loop)
-        self.transactions[msg.method][msg.cseq] = transaction
-        async for response in transaction.start():
-            yield response
-
-    async def start_proxy_transaction(self, msg, timeout=5):
-        if msg.cseq not in self.transactions[msg.method]:
-            transaction = ProxyTransaction(dialog=self, original_msg=msg, loop=self.app.loop, timeout=timeout)
-            self.transactions[msg.method][msg.cseq] = transaction
-            async for response in transaction.start():
-                yield response
-        else:
-            LOG.debug('Message already transmitted: %s %s, %s', msg.cseq, msg.method, msg.headers['Call-ID'])
-            self.transactions[msg.method][msg.cseq].retransmit()
-        return
-
-    def end_transaction(self, transaction):
-        to_delete = list()
-        for method, values in self.transactions.items():
-            for cseq, t in values.items():
-                if transaction is t:
-                    transaction.close()
-                    to_delete.append((method, cseq))
-
-        for item in to_delete:
-            del self.transactions[item[0]][item[1]]
-
-    async def send(self, msg, as_request=False):
-        # This allow to send string as SIP message. msg only need an encode method.
-
-        if issubclass(Request, msg) and msg.method != 'ACK':
-            return await self.start_unreliable_transaction(msg)
-        elif isinstance(Response, msg) or msg.method == 'ACK':
-            self.peer.send_message(msg)
-            return
-        elif as_request:
-            return await self.start_unreliable_transaction(msg)
-        else:
-            self.peer.send_message(msg)
-            return
-
-    async def reply(self, request, status_code, status_message=None, payload=None, headers=None, contact_details=None,
-                    wait_for_ack=False):
-        msg = self._prepare_response(request, status_code, status_message, payload, headers, contact_details)
-        if wait_for_ack:
-            return await self.start_unreliable_transaction(msg, method='ACK')
-        else:
-            self.peer.send_message(msg)
-
-    def _prepare_response(self, request, status_code, status_message=None, payload=None, headers=None,
-                          contact_details=None):
-        self.from_details.add_tag()
-
-        if contact_details:
-            self.contact_details = contact_details
-
-        headers = CIMultiDict(headers or {})
-
-        if 'User-Agent' not in headers:
-            headers['User-Agent'] = self.app.defaults['user_agent']
-
-        headers['Call-ID'] = self.call_id
-        headers['Via'] = request.headers['Via']
-
-        msg = Response(
-            status_code=status_code,
-            status_message=status_message,
-            headers=headers,
-            from_details=self.to_details,
-            to_details=self.from_details,
-            contact_details=self.contact_details,
-            payload=payload,
-            cseq=request.cseq,
-            method=request.method
-        )
-        return msg
-
-    async def request(self, method, contact_details=None, headers=None, payload=None):
-        msg = self._prepare_request(method, contact_details, headers, payload)
-        if msg.method != 'ACK':
-            return await self.start_unreliable_transaction(msg)
-        else:
-            self.peer.send_message(msg)
-
-    async def request_all(self, method, contact_details=None, headers=None, payload=None):
-        msg = self._prepare_request(method, contact_details, headers, payload)
-        if msg.method != 'ACK':
-            async for response in self.start_queue_transaction(msg):
-                yield response
-        else:
-            self.peer.send_message(msg)
+            if msg.method != 'ACK':
+                # TODO: Hack to suppress warning on ACK messages,
+                # since we don't quite handle them correctly. They're
+                # ignored, for now...
+                LOG.debug('Response without Request. The Transaction may already be closed. \n%s', msg)
 
     def _prepare_request(self, method, contact_details=None, headers=None, payload=None, cseq=None, to_details=None):
         self.from_details.add_tag()
@@ -209,7 +85,29 @@ class Dialog:
         )
         return msg
 
-    def close(self):
+    async def start(self, *, expires=None):
+        # TODO: this is a hack
+        headers = {}
+        if expires:
+            headers['Expires'] = expires
+        return await self.request(self.original_msg.method, headers=headers)
+
+    async def unauthorized(self, msg):
+        self._nonce = utils.gen_str(10)
+        headers = CIMultiDict()
+        headers['WWW-Authenticate'] = str(Auth(nonce=self._nonce, algorithm='md5', realm='sip'))
+        await self.reply(msg, status_code=401, headers=headers)
+
+    def validate_auth(self, msg, password):
+        if msg.auth and msg.auth.validate(password, self._nonce):
+            self._nonce = None
+            return True
+        elif msg.method == 'CANCEL':
+            return True
+        else:
+            return False
+
+    def close(self, *, fast=False):
         self.peer._close_dialog(self.call_id)
         self._close()
 
@@ -241,33 +139,128 @@ class Dialog:
             for transaction in transactions.values():
                 transaction._error(ConnectionError)
 
-    async def _register(self, headers=None, expires=1800, *args, **kwargs):
+    async def start_unreliable_transaction(self, msg, method=None):
+        transaction = UnreliableTransaction(self, original_msg=msg, loop=self.app.loop)
+        self.transactions[method or msg.method][msg.cseq] = transaction
+        return await transaction.start()
+
+    async def start_proxy_transaction(self, msg, timeout=5):
+        if msg.cseq not in self.transactions[msg.method]:
+            transaction = ProxyTransaction(dialog=self, original_msg=msg, loop=self.app.loop, timeout=timeout)
+            self.transactions[msg.method][msg.cseq] = transaction
+            async for response in transaction.start():
+                yield response
+        else:
+            LOG.debug('Message already transmitted: %s %s, %s', msg.cseq, msg.method, msg.headers['Call-ID'])
+            self.transactions[msg.method][msg.cseq].retransmit()
+        return
+
+    def end_transaction(self, transaction):
+        to_delete = list()
+        for method, values in self.transactions.items():
+            for cseq, t in values.items():
+                if transaction is t:
+                    transaction.close()
+                    to_delete.append((method, cseq))
+
+        for item in to_delete:
+            del self.transactions[item[0]][item[1]]
+
+    async def request(self, method, contact_details=None, headers=None, payload=None):
+        msg = self._prepare_request(method, contact_details, headers, payload)
+        if msg.method != 'ACK':
+            return await self.start_unreliable_transaction(msg)
+        else:
+            self.peer.send_message(msg)
+
+    async def reply(self, request, status_code, status_message=None, payload=None, headers=None, contact_details=None):
+        msg = self._prepare_response(request, status_code, status_message, payload, headers, contact_details)
+        self.peer.send_message(msg)
+
+    def _prepare_response(self, request, status_code, status_message=None, payload=None, headers=None,
+                          contact_details=None):
+        self.from_details.add_tag()
+
+        if contact_details:
+            self.contact_details = contact_details
+
         headers = CIMultiDict(headers or {})
 
-        if 'Allow' not in headers:
-            headers['Allow'] = 'INVITE, ACK, CANCEL, OPTIONS, BYE, REFER, SUBSCRIBE, NOTIFY, INFO, PUBLISH'
+        if 'User-Agent' not in headers:
+            headers['User-Agent'] = self.app.defaults['user_agent']
 
-        if 'Expires' not in headers:
-            headers['Expires'] = int(expires)
+        headers['Call-ID'] = self.call_id
+        headers['Via'] = request.headers['Via']
 
-        if 'Allow-Events' not in headers:
-            headers['Allow-Events'] = 'talk,hold,conference,refer,check-sync'
+        msg = Response(
+            status_code=status_code,
+            status_message=status_message,
+            headers=headers,
+            from_details=self.to_details,
+            to_details=self.from_details,
+            contact_details=self.contact_details,
+            payload=payload,
+            cseq=request.cseq,
+            method=request.method
+        )
+        return msg
 
-        return await self.request('REGISTER', headers=headers, *args, **kwargs)
+    def __repr__(self):
+        return f'<{self.__class__.__name__} call_id={self.call_id}, peer={self.peer}>'
 
-    async def _subscribe(self, headers=None, expires=1800, *args, **kwargs):
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc_info):
+        await self.close()
+
+    async def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        return await self.recv()
+
+
+class Dialog(DialogBase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self._nonce = None
+        self._closing = None
+        self._incoming = asyncio.Queue()
+
+    async def receive_message(self, msg):
+        if self._closing:
+            self._closing.cancel()
+
+        if self.cseq < msg.cseq:
+            self.cseq = msg.cseq
+
+        if isinstance(msg, Response) or msg.method == 'ACK':
+            return self._receive_response(msg)
+        else:
+            return await self._receive_request(msg)
+
+    async def _receive_request(self, msg):
+        self.peer._bookkeeping(msg, self.call_id)
+
+        if 'tag' in msg.from_details['params']:
+            self.to_details['params']['tag'] = msg.from_details['params']['tag']
+
+        await self._incoming.put(msg)
+        self._maybe_close(msg)
+
+    async def refresh(self, headers=None, expires=1800, *args, **kwargs):
         headers = CIMultiDict(headers or {})
-
-        if 'Event' not in headers:
-            headers['Event'] = 'dialog'
-
-        if 'Accept' not in headers:
-            headers['Accept'] = 'application/dialog-info+xml'
-
         if 'Expires' not in headers:
             headers['Expires'] = int(expires)
+        return await self.request(self.original_msg.method, headers=headers, *args, **kwargs)
 
-        return await self.request('SUBSCRIBE', headers=headers, *args, **kwargs)
+    async def close(self, fast=False, headers=None, *args, **kwargs):
+        headers = CIMultiDict(headers or {})
+        if 'Expires' not in headers:
+            headers['Expires'] = 0
+        return await self.request(self.original_msg.method, headers=headers, *args, **kwargs)
 
     async def notify(self, *args, headers=None, **kwargs):
         headers = CIMultiDict(headers or {})
@@ -283,9 +276,91 @@ class Dialog:
 
         return await self.request('NOTIFY', *args, headers=headers, **kwargs)
 
-    async def invite(self, *args, **kwargs):
-        async for response in self.request_all('INVITE', *args, **kwargs):
-            yield response
+    def cancel(self, *args, **kwargs):
+        cancel = self._prepare_request('CANCEL', *args, **kwargs)
+        self.peer.send_message(cancel)
+
+    async def recv(self):
+        return await self._incoming.get()
+
+
+class InviteDialog(DialogBase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(method="INVITE", *args, **kwargs)
+
+        self._queue = asyncio.Queue()
+        self._state = CallState.Calling
+        self._waiter = asyncio.Future()
+
+    async def receive_message(self, msg):  # noqa: C901
+        async def set_result(msg):
+            self.ack(msg)
+            if not self._waiter.done():
+                self._waiter.set_result(msg)
+
+        async def handle_calling_state(msg):
+            if 100 <= msg.status_code < 200:
+                self._state = CallState.Proceeding
+
+            elif msg.status_code == 200:
+                self._state = CallState.Terminated
+                await set_result(msg)
+
+            elif 300 <= msg.status_code < 700:
+                self._state = CallState.Completed
+                await set_result(msg)
+
+        async def handle_proceeding_state(msg):
+            if 100 <= msg.status_code < 200:
+                pass
+
+            elif msg.status_code == 200:
+                self._state = CallState.Terminated
+                await set_result(msg)
+
+            elif 300 <= msg.status_code < 700:
+                self._state = CallState.Completed
+                await set_result(msg)
+
+        async def handle_completed_state(msg):
+            # Any additional messages in this state MUST be acked but
+            # are NOT to be passed up
+            self.ack(msg)
+
+        await self._queue.put(msg)
+
+        # TODO: sip timers and flip to Terminated after timeout
+        if self._state == CallState.Calling:
+            await handle_calling_state(msg)
+
+        elif self._state == CallState.Proceeding:
+            await handle_proceeding_state(msg)
+
+        elif self._state == CallState.Completed:
+            await handle_completed_state(msg)
+
+        elif self._state == CallState.Terminated:
+            if isinstance(msg, Response) or msg.method == 'ACK':
+                return self._receive_response(msg)
+            else:
+                return await self._receive_request(msg)
+
+    @property
+    def state(self):
+        return self._state
+
+    async def start(self, *, expires=None):
+        # TODO: this is a hack
+        self.peer.send_message(self.original_msg)
+
+    async def wait_for_terminate(self):
+        while not self._waiter.done():
+            yield await self._queue.get()
+
+    async def ready(self):
+        msg = await self._waiter
+        if msg.status_code != 200:
+            raise RuntimeError("INVITE failed with {}".format(msg.status_code))
 
     def ack(self, msg, headers=None, *args, **kwargs):
         headers = CIMultiDict(headers or {})
@@ -294,24 +369,22 @@ class Dialog:
         ack = self._prepare_request('ACK', cseq=msg.cseq, to_details=msg.to_details, headers=headers, *args, **kwargs)
         self.peer.send_message(ack)
 
-    def cancel(self, *args, **kwargs):
-        cancel = self._prepare_request('CANCEL', *args, **kwargs)
-        self.peer.send_message(cancel)
+    def end_transaction(self, transaction):
+        to_delete = list()
+        for method, values in self.transactions.items():
+            for cseq, t in values.items():
+                if transaction is t:
+                    transaction.close()
+                    to_delete.append((method, cseq))
 
-    def __enter__(self):
-        return self
+        for item in to_delete:
+            del self.transactions[item[0]][item[1]]
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        self.close()
+    async def close(self):
+        msg = self._prepare_request('BYE')
+        transaction = UnreliableTransaction(self, original_msg=msg, loop=self.app.loop)
+        self.transactions[msg.method][msg.cseq] = transaction
+        return await transaction.start()
 
-    async def recv(self):
-        return await self._incoming.get()
-
-    async def __aiter__(self):
-        return self
-
-    async def __anext__(self):
-        return await self.recv()
-
-    def __repr__(self):
-        return '<{0} call_id={1}, peer={2}>'.format(self.__class__.__name__, self.call_id, self.peer)
+    def _close(self):
+        pass

--- a/examples/back_to_back/client.py
+++ b/examples/back_to_back/client.py
@@ -43,8 +43,7 @@ async def run_subscription(peer, user, duration):
     with contextlib.suppress(asyncio.TimeoutError):
         await asyncio.wait_for(reader(), timeout=duration)
 
-    # TODO: needs a better API
-    await subscription._subscribe(expires=0)
+    await subscription.close()
 
 
 async def start(app, protocol, target, duration):

--- a/examples/back_to_back/util.py
+++ b/examples/back_to_back/util.py
@@ -8,4 +8,4 @@ class Registration:
         self._dialog = await self._peer.register(**self._kwargs)
 
     async def __aexit__(self, *exc_info):
-        await self._dialog._register(expires=0)
+        await self._dialog.close()

--- a/examples/call/server.py
+++ b/examples/call/server.py
@@ -1,0 +1,76 @@
+import argparse
+import asyncio
+import logging
+
+import aiosip
+
+sip_config = {
+    'srv_host': 'xxxxxx',
+    'srv_port': '7000',
+    'realm': 'XXXXXX',
+    'user': 'YYYYYY',
+    'pwd': 'ZZZZZZ',
+    'local_ip': '127.0.0.1',
+    'local_port': 6000
+}
+
+
+async def on_invite(request, message):
+    print('Call ringing!')
+    dialog = await request.prepare(status_code=100)
+    await dialog.reply(message, status_code=180)
+
+    await asyncio.sleep(3)
+    await dialog.reply(message, status_code=200)
+    print('Call started!')
+
+    async for message in dialog:
+        await dialog.reply(message, 200)
+        if message.method == 'BYE':
+            break
+
+
+def start(app, protocol):
+    app.loop.run_until_complete(
+        app.run(
+            protocol=protocol,
+            local_addr=(sip_config['local_ip'], sip_config['local_port'])))
+
+    print('Serving on {} {}'.format(
+        (sip_config['local_ip'], sip_config['local_port']), protocol))
+
+    try:
+        app.loop.run_forever()
+    except KeyboardInterrupt:
+        pass
+
+    print('Closing')
+    app.loop.run_until_complete(app.close())
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-p', '--protocol', default='udp')
+    args = parser.parse_args()
+
+    loop = asyncio.get_event_loop()
+    app = aiosip.Application(loop=loop)
+    app.dialplan.add_user('aiosip', {
+        'INVITE': on_invite
+    })
+
+    if args.protocol == 'udp':
+        start(app, aiosip.UDP)
+    elif args.protocol == 'tcp':
+        start(app, aiosip.TCP)
+    elif args.protocol == 'ws':
+        start(app, aiosip.WS)
+    else:
+        raise RuntimeError("Unsupported protocol: {}".format(args.protocol))
+
+    loop.close()
+
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.DEBUG)
+    main()


### PR DESCRIPTION
Closed #77 and creates a new one because I ended up taking a slightly different approach with deeper changes that I'm more happy with.

This PR starts by reworks the dialog API so it **must** be paired with an initial message. This lets me removes the private `_subscribe` and `_register` methods in favour of a new `refresh` and `close` API that sends the right follow up message with the right "Expires" header.

Then I implement some basic INVITE dialog support. This requires its own dialog class implementation as it has its own call state information that needs to be tracked. INVITE really is a special case, and thus needs to be treated differently.

I think this lends itself a lot better to having a good REGISTER/SUBSCRIBE client API, but its also making it more and more clear that we need different abstractions for server and client dialogs. Currently they're represented by the same abstraction, but they're setup and operation is slightly different.

The INVITE support it also not perfect. We do not properly handle ACK yet, and I've taken to just suppressing the warning message instead. I'll continue to work on this, but for the moment I want to start using the INVITE APIs and see if they're actually sensible.
