### PR TITLE
Redo dialog tracking

### DIFF
--- a/aiosip/application.py
+++ b/aiosip/application.py
@@ -138,8 +138,10 @@ class Application(MutableMapping):
             await dialog.receive_message(msg)
             return
 
-        # If we got an ACK, but nowhere to deliver it, drop it
-        if msg.method == 'ACK':
+        # If we got an ACK, but nowhere to deliver it, drop it. If we
+        # got a response without an associated message (likely a stale
+        # retransmission, drop it)
+        if msg.method == 'ACK' or hasattr(msg, 'status_code'):
             return
 
         router = await self.dialplan.resolve(

--- a/aiosip/contact.py
+++ b/aiosip/contact.py
@@ -71,6 +71,37 @@ class Contact(MutableMapping):
             r += ';%s' % str(params)
         return r
 
+    @property
+    def scheme(self):
+        return self._contact['uri']['scheme']
+
+    @property
+    def transport(self):
+        transport = self._contact['params'].get('transport')
+        if not transport:
+            return 'tcp' if self.scheme == 'sips' else 'udp'
+        return transport
+
+    @property
+    def host(self):
+        return self._contact['uri']['host']
+
+    @property
+    def port(self):
+        port = self._contact['uri'].get('port')
+        if not port:
+            if self.scheme == 'sips':
+                return 5061
+            elif self.transport == 'udp':
+                return 5060
+            else:
+                return 5080
+        return port
+
+    @property
+    def details(self):
+        return self.scheme, self.transport, self.host, self.port
+
     # MutableMapping API
     def __eq__(self, other):
         return self is other

--- a/aiosip/via.py
+++ b/aiosip/via.py
@@ -1,0 +1,58 @@
+import re
+import logging
+
+from collections import MutableMapping
+
+from .param import Param
+
+
+VIA_PATTERNS = [
+    re.compile('SIP/2.0/(?P<protocol>[a-zA-Z]+)'
+               '[ \t]*'
+               '(?P<sentby>[^;]+)'
+               '(?:;(?P<params>.*))'),
+]
+
+
+LOG = logging.getLogger(__name__)
+
+
+class Via(MutableMapping):
+    def __init__(self, *args, **kwargs):
+        self._via = dict(*args, **kwargs)
+
+        params = self._via.get('params')
+        if not params:
+            self._via['params'] = Param()
+        if not isinstance(params, Param):
+            self._via['params'] = Param(self._via['params'])
+
+        self._via['host'], self._via['port'] = self._via['sentby'].rsplit(':', 1)
+
+    @classmethod
+    def from_header(cls, via):
+        for s in VIA_PATTERNS:
+            m = s.match(via)
+            if m:
+                return cls(m.groupdict())
+        else:
+            raise ValueError('Not valid via address')
+
+    # MutableMapping API
+    def __eq__(self, other):
+        return self is other
+
+    def __getitem__(self, key):
+        return self._via[key]
+
+    def __setitem__(self, key, value):
+        self._via[key] = value
+
+    def __delitem__(self, key):
+        del self._via[key]
+
+    def __len__(self):
+        return len(self._via)
+
+    def __iter__(self):
+        return iter(self._via)

--- a/tests/test_sip_proxy.py
+++ b/tests/test_sip_proxy.py
@@ -71,7 +71,11 @@ async def test_proxy_notify(test_server, test_proxy, protocol, loop, from_detail
                 dialog.peer.proxy_response(proxy_response)
 
         # TODO: refactor
-        subscription = peer._dialogs[message.headers['Call-ID']]
+        subscription = request.app._dialogs[frozenset((
+            message.to_details.details,
+            message.from_details.details,
+            message.headers['Call-ID']
+        ))]
 
         async for msg in subscription:
             async for proxy_response in dialog.peer.proxy_request(subscription, msg):


### PR DESCRIPTION
This PR reworks how dialogs are tracked

Its actually wrong to try and first determine the remote address first, and then use that to work out which dialog a message belongs to - we don't have enough information to accurately make that determination.

All we have is sufficient information to determine which dialog and transaction a message belongs to.

Also in the case that a new inbound message arrives and needs to be run through the dialplan, the Contact header should be used instead of the socket's peername for figuring out where to return traffic.

So the current design needs to be broken and globally track all dialogs. Once we've established the dialog, we can get peer information. Dialogs are also now tracked by the set of the address contained in the To and From headers plus the Call-ID. This is much closer to correct, but still a little lacking.

This isn't quite correct, and needs to shift to using just the tags from the To and From header, but that requires some deeper changes as we don't know this information until the response has returned.

Unfortunately this completely breaks a lot of the statistics stored on the peers, and I've removed them for the time being.

Thanks to @moises-silva for the help with this.