### PR TITLE
__aiter__ must be a regular function

### DIFF
--- a/aiosip/dialog.py
+++ b/aiosip/dialog.py
@@ -246,7 +246,7 @@ class DialogBase:
     async def __aexit__(self, *exc_info):
         await self.close()
 
-    async def __aiter__(self):
+    def __aiter__(self):
         return self
 
     async def __anext__(self):


### PR DESCRIPTION
Necessary for aiosip under python 3.7

Sorry for my absence, had a really busy couple of months paired with some nasty hardware failures (my only laptop failed, had to replace it) - and I'm still not back up to 100%.