### PR TITLE
import MutableMapping from collections.abc

### DIFF
--- a/aiosip/application.py
+++ b/aiosip/application.py
@@ -10,7 +10,7 @@ import traceback
 
 __all__ = ['Application']
 
-from collections import MutableMapping
+from collections.abc import MutableMapping
 
 from . import __version__
 from .dialog import Dialog

--- a/aiosip/auth.py
+++ b/aiosip/auth.py
@@ -1,4 +1,4 @@
-from collections import MutableMapping
+from collections.abc import MutableMapping
 from enum import Enum
 from hashlib import md5
 import logging

--- a/aiosip/contact.py
+++ b/aiosip/contact.py
@@ -2,7 +2,7 @@ import re
 import string
 import logging
 
-from collections import MutableMapping
+from collections.abc import MutableMapping
 
 from .param import Param
 from .uri import Uri

--- a/aiosip/param.py
+++ b/aiosip/param.py
@@ -1,4 +1,4 @@
-from collections import MutableMapping
+from collections.abc import MutableMapping
 
 
 class Param(MutableMapping):

--- a/aiosip/uri.py
+++ b/aiosip/uri.py
@@ -2,7 +2,7 @@ import re
 import logging
 
 
-from collections import MutableMapping
+from collections.abc import MutableMapping
 
 from .param import Param
 

--- a/aiosip/via.py
+++ b/aiosip/via.py
@@ -1,7 +1,7 @@
 import re
 import logging
 
-from collections import MutableMapping
+from collections.abc import MutableMapping
 
 from .param import Param
 


### PR DESCRIPTION
In python3.7, importing MutableMapping directly from collections raise a deprecation warning:
```
>>> from collections import MutableMapping
__main__:1: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
```
Importing from collections.abc solve the warning :-)

P.S MutableMapping is part of collections.abc since 3.3